### PR TITLE
feat: Add Hall domain and create Hall API

### DIFF
--- a/src/main/java/com/dayaeyak/performance/PerformanceServiceApplication.java
+++ b/src/main/java/com/dayaeyak/performance/PerformanceServiceApplication.java
@@ -2,10 +2,11 @@ package com.dayaeyak.performance;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PerformanceServiceApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(PerformanceServiceApplication.class, args);
 	}

--- a/src/main/java/com/dayaeyak/performance/common/entity/BaseEntity.java
+++ b/src/main/java/com/dayaeyak/performance/common/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.dayaeyak.performance.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", updatable = false, nullable = false)
+    protected LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    /* 소프트 삭제 메서드 */
+    public void delete(){
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/common/exception/CustomException.java
+++ b/src/main/java/com/dayaeyak/performance/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.dayaeyak.performance.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+  private final HttpStatus httpStatus;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.httpStatus = errorCode.getHttpStatus();
+  }
+}

--- a/src/main/java/com/dayaeyak/performance/common/exception/ErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/common/exception/ErrorCode.java
@@ -1,0 +1,8 @@
+package com.dayaeyak.performance.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/com/dayaeyak/performance/common/exception/GlobalErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/common/exception/GlobalErrorCode.java
@@ -1,0 +1,17 @@
+package com.dayaeyak.performance.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
+    USER_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "사용자 서비스에 일시적인 장애가 발생했습니다."),
+    INVALID_PAGE_OR_SIZE(HttpStatus.BAD_REQUEST, "page, size는 0 이상의 정수여야 합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
@@ -1,0 +1,25 @@
+package com.dayaeyak.performance.domain.hall;
+
+import com.dayaeyak.performance.domain.hall.dto.request.CreateHallRequestDto;
+import com.dayaeyak.performance.domain.hall.dto.response.CreateHallResponseDto;
+import com.dayaeyak.performance.utils.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/halls")
+@RequiredArgsConstructor
+public class HallController {
+    private final HallService hallService;
+
+    /*공연장 생성 API*/
+    @PostMapping
+    public ApiResponse<CreateHallResponseDto> createHall(@Validated @RequestBody CreateHallRequestDto requestDto) {
+        return ApiResponse.success(HttpStatus.CREATED, "공연장이 생성되었습니다.", hallService.createHall(requestDto));
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
@@ -6,10 +6,7 @@ import com.dayaeyak.performance.utils.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/halls")
@@ -19,6 +16,7 @@ public class HallController {
 
     /*공연장 생성 API*/
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<CreateHallResponseDto> createHall(@Validated @RequestBody CreateHallRequestDto requestDto) {
         return ApiResponse.success(HttpStatus.CREATED, "공연장이 생성되었습니다.", hallService.createHall(requestDto));
     }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
@@ -5,8 +5,12 @@ import com.dayaeyak.performance.domain.hall.dto.response.CreateHallResponseDto;
 import com.dayaeyak.performance.utils.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/halls")
@@ -16,8 +20,8 @@ public class HallController {
 
     /*공연장 생성 API*/
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<CreateHallResponseDto> createHall(@Validated @RequestBody CreateHallRequestDto requestDto) {
-        return ApiResponse.success(HttpStatus.CREATED, "공연장이 생성되었습니다.", hallService.createHall(requestDto));
+    public ResponseEntity<ApiResponse<CreateHallResponseDto>> createHall(
+            @Validated @RequestBody CreateHallRequestDto requestDto) {
+        return ApiResponse.success(HttpStatus.CREATED.value(), "공연장이 생성되었습니다.", hallService.createHall(requestDto));
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/HallService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/HallService.java
@@ -1,0 +1,49 @@
+package com.dayaeyak.performance.domain.hall;
+
+import com.dayaeyak.performance.domain.hall.dto.request.CreateHallRequestDto;
+import com.dayaeyak.performance.domain.hall.dto.response.CreateHallResponseDto;
+import com.dayaeyak.performance.domain.hall.entity.Hall;
+import com.dayaeyak.performance.domain.hall.entity.HallSection;
+import com.dayaeyak.performance.domain.hall.repository.HallRepository;
+import com.dayaeyak.performance.domain.hall.repository.HallSectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HallService {
+    private final HallRepository hallRepository;
+    private final HallSectionRepository hallSectionRepository;
+
+    @Transactional
+    public CreateHallResponseDto createHall(CreateHallRequestDto requestDto) {
+        // 공연장 엔티티 생성 및 저장
+        Hall hall = Hall.builder()
+                .hallName(requestDto.hallName())
+                .address(requestDto.address())
+                .city(requestDto.city())
+                .capacity(requestDto.capacity())
+                .build();
+        Hall savedHall = hallRepository.save(hall);
+
+        // 공연장 구역 엔티티 리스트 생성 및 저장
+        List<HallSection> hallSections = requestDto.sections().stream()
+                .map(sectionDto -> HallSection.builder()
+                        .hall(savedHall)
+                        .sectionName(sectionDto.sectionName())
+                        .seats(sectionDto.seats())
+                        .seatPrice(sectionDto.seatPrice())
+                        .build())
+                .collect(Collectors.toList());
+
+        List<HallSection> savedHallSections = hallSectionRepository.saveAll(hallSections);
+
+        // 응답 DTO 생성 및 반환
+        return new CreateHallResponseDto(savedHall.getHallId());
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/HallService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/HallService.java
@@ -1,9 +1,11 @@
 package com.dayaeyak.performance.domain.hall;
 
+import com.dayaeyak.performance.common.exception.CustomException;
 import com.dayaeyak.performance.domain.hall.dto.request.CreateHallRequestDto;
 import com.dayaeyak.performance.domain.hall.dto.response.CreateHallResponseDto;
 import com.dayaeyak.performance.domain.hall.entity.Hall;
 import com.dayaeyak.performance.domain.hall.entity.HallSection;
+import com.dayaeyak.performance.domain.hall.exception.HallErrorCode;
 import com.dayaeyak.performance.domain.hall.repository.HallRepository;
 import com.dayaeyak.performance.domain.hall.repository.HallSectionRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,12 @@ public class HallService {
                 .city(requestDto.city())
                 .capacity(requestDto.capacity())
                 .build();
-        Hall savedHall = hallRepository.save(hall);
+        Hall savedHall;
+        try{
+            savedHall = hallRepository.save(hall);
+        } catch (Exception e){
+            throw new CustomException(HallErrorCode.HALL_NAME_DUPLICATED);
+        }
 
         // 공연장 구역 엔티티 리스트 생성 및 저장
         List<HallSection> hallSections = requestDto.sections().stream()

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallRequestDto.java
@@ -1,0 +1,14 @@
+package com.dayaeyak.performance.domain.hall.dto.request;
+
+import com.dayaeyak.performance.domain.hall.enums.Region;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record CreateHallRequestDto(
+        @NotBlank(message = "공연장 이름은 필수 입력값입니다.") String hallName,
+        @NotBlank(message = "공연장 주소는 필수 입력값입니다.") String address,
+        @NotBlank(message = "공연장이 위치한 지역을 입력해주세요.") Region city,
+        @NotBlank(message = "공연장의 수용인원을 입력해주세요.") Integer capacity,
+        List<CreateHallSectionDto> sections
+) { }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallRequestDto.java
@@ -2,13 +2,14 @@ package com.dayaeyak.performance.domain.hall.dto.request;
 
 import com.dayaeyak.performance.domain.hall.enums.Region;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record CreateHallRequestDto(
         @NotBlank(message = "공연장 이름은 필수 입력값입니다.") String hallName,
         @NotBlank(message = "공연장 주소는 필수 입력값입니다.") String address,
-        @NotBlank(message = "공연장이 위치한 지역을 입력해주세요.") Region city,
-        @NotBlank(message = "공연장의 수용인원을 입력해주세요.") Integer capacity,
+        @NotNull(message = "공연장이 위치한 지역을 입력해주세요.") Region city,
+        @NotNull(message = "공연장의 수용인원을 입력해주세요.") Integer capacity,
         List<CreateHallSectionDto> sections
 ) { }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallSectionDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallSectionDto.java
@@ -1,0 +1,13 @@
+package com.dayaeyak.performance.domain.hall.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateHallSectionDto(
+        @NotBlank(message = "구역 이름은 필수 입력값입니다.") String sectionName,
+        @NotNull(message = "좌석 수량을 입력해주세요.")
+        @Min(value = 0, message = "좌석 수량은 0 이상이어야 합니다.") Integer seats,
+        @NotNull(message = "좌석 가격을 입력해주세요.")
+        @Min(value = 0, message = "좌석 가격은 0원 이상이어야 합니다.") Integer seatPrice) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/CreateHallResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/CreateHallResponseDto.java
@@ -1,0 +1,6 @@
+package com.dayaeyak.performance.domain.hall.dto.response;
+
+public record CreateHallResponseDto(
+    Long hallId
+) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/entity/Hall.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/entity/Hall.java
@@ -1,0 +1,40 @@
+package com.dayaeyak.performance.domain.hall.entity;
+
+import com.dayaeyak.performance.common.entity.BaseEntity;
+import com.dayaeyak.performance.domain.hall.enums.Region;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "halls")
+public class Hall extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long hallId;
+
+    @Column(length = 100, nullable = false, unique = true)
+    private String hallName;
+
+    @Column(length = 100, nullable = false)
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Region city;
+
+    @Column(nullable = false)
+    private Integer capacity;
+
+    @Builder
+    public Hall(String hallName, String address, Region city, Integer capacity) {
+        this.hallName = hallName;
+        this.address = address;
+        this.city = city;
+        this.capacity = capacity;
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/entity/HallSection.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/entity/HallSection.java
@@ -1,0 +1,39 @@
+package com.dayaeyak.performance.domain.hall.entity;
+
+import com.dayaeyak.performance.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "hall_sections")
+public class HallSection extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long hallSectionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hall_id", nullable = false)
+    private Hall hall;
+
+    @Column(length = 50, nullable = false)
+    private String sectionName;
+
+    @Column(nullable = false)
+    private Integer seats;
+
+    @Column(nullable = false)
+    private Integer seatPrice;
+
+    @Builder
+    public HallSection(Hall hall, String sectionName, Integer seats, Integer seatPrice) {
+        this.hall = hall;
+        this.sectionName = sectionName;
+        this.seats = seats;
+        this.seatPrice = seatPrice;
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/enums/Region.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/enums/Region.java
@@ -1,0 +1,24 @@
+package com.dayaeyak.performance.domain.hall.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Region {
+    SEOUL("서울"),
+    INCHEON("인천"),
+    GYEONGGI("경기"),
+    GANGWON("강원"),
+    CHUNGCHEONG("충청"),
+    DAEJEON("대전"),
+    JEOLLA("전라"),
+    GWANGJU("광주"),
+    GYEONGSANG("경상"),
+    DAEGU("대구"),
+    ULSAN("울산"),
+    BUSAN("부산"),
+    JEJU("제주");
+
+    private final String city;
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/exception/HallErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/exception/HallErrorCode.java
@@ -1,0 +1,15 @@
+package com.dayaeyak.performance.domain.hall.exception;
+
+import com.dayaeyak.performance.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum HallErrorCode implements ErrorCode {
+    HALL_NOT_FOUND(HttpStatus.NOT_FOUND, "공연장 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/exception/HallErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/exception/HallErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum HallErrorCode implements ErrorCode {
+    HALL_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 공연장 이름이 존재합니다."),
     HALL_NOT_FOUND(HttpStatus.NOT_FOUND, "공연장 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dayaeyak/performance/domain/hall/repository/HallRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/repository/HallRepository.java
@@ -1,0 +1,8 @@
+package com.dayaeyak.performance.domain.hall.repository;
+
+import com.dayaeyak.performance.domain.hall.entity.Hall;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HallRepository extends JpaRepository<Hall,Long> {
+
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/repository/HallSectionRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/repository/HallSectionRepository.java
@@ -1,0 +1,7 @@
+package com.dayaeyak.performance.domain.hall.repository;
+
+import com.dayaeyak.performance.domain.hall.entity.HallSection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HallSectionRepository extends JpaRepository<HallSection, Long> {
+}

--- a/src/main/java/com/dayaeyak/performance/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dayaeyak/performance/handler/GlobalExceptionHandler.java
@@ -3,10 +3,10 @@ package com.dayaeyak.performance.handler;
 import com.dayaeyak.performance.common.exception.CustomException;
 import com.dayaeyak.performance.utils.ApiResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.stream.Collectors;
@@ -14,20 +14,18 @@ import java.util.stream.Collectors;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ApiResponse<?> handleCustomException(CustomException e){
-        return ApiResponse.error(e.getHttpStatus(), e.getMessage());
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e){
+        return ApiResponse.error(e.getHttpStatus().value(), e.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ApiResponse<?> handleNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<Void>> handleNotValidException(MethodArgumentNotValidException e) {
         String errorMessage = e.getBindingResult()
                 .getFieldErrors()
                 .stream()
                 .map(FieldError::getDefaultMessage)
                 .collect(Collectors.joining("\n"));
-        return ApiResponse.error(HttpStatus.BAD_REQUEST, errorMessage);
+        return ApiResponse.error(HttpStatus.BAD_REQUEST.value(), errorMessage);
 
     }
 }

--- a/src/main/java/com/dayaeyak/performance/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dayaeyak/performance/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.stream.Collectors;
@@ -13,11 +14,13 @@ import java.util.stream.Collectors;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<?> handleCustomException(CustomException e){
         return ApiResponse.error(e.getHttpStatus(), e.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<?> handleNotValidException(MethodArgumentNotValidException e) {
         String errorMessage = e.getBindingResult()
                 .getFieldErrors()

--- a/src/main/java/com/dayaeyak/performance/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dayaeyak/performance/handler/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.dayaeyak.performance.handler;
+
+import com.dayaeyak.performance.common.exception.CustomException;
+import com.dayaeyak.performance.utils.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<?> handleCustomException(CustomException e){
+        return ApiResponse.error(e.getHttpStatus(), e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> handleNotValidException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining("\n"));
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, errorMessage);
+
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/utils/ApiResponse.java
+++ b/src/main/java/com/dayaeyak/performance/utils/ApiResponse.java
@@ -2,28 +2,31 @@ package com.dayaeyak.performance.utils;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 @Getter
 @AllArgsConstructor
 public class ApiResponse<T> {
-    private HttpStatus httpStatus;
     private String message;
     private T data;
 
-    public static <T> ApiResponse<T> success(HttpStatus status,T data) {
-        return new ApiResponse<>(status,null,data);
+    public static <T> ResponseEntity<ApiResponse<T>> success(int status, T data) {
+        return ResponseEntity.status(status)
+                .body(new ApiResponse<>(null, data));
     }
 
-    public static <T> ApiResponse<T> success(HttpStatus status, String message) {
-        return new ApiResponse<>(status,message,null);
+    public static <T> ResponseEntity<ApiResponse<T>> success(int status, String message) {
+        return ResponseEntity.status(status)
+                .body(new ApiResponse<>(message, null));
     }
 
-    public static <T> ApiResponse<T> success(HttpStatus status, String message, T data) {
-        return new ApiResponse<>(status,message,data);
+    public static <T> ResponseEntity<ApiResponse<T>> success(int status, String message, T data) {
+        return ResponseEntity.status(status)
+                .body(new ApiResponse<>(message, data));
     }
 
-    public static <T> ApiResponse<T> error(HttpStatus status, String message){
-        return new ApiResponse<>(status, message, null);
+    public static <T> ResponseEntity<ApiResponse<T>> error(int status, String message){
+        return ResponseEntity.status(status)
+                .body(new ApiResponse<>(message, null));
     }
 }

--- a/src/main/java/com/dayaeyak/performance/utils/ApiResponse.java
+++ b/src/main/java/com/dayaeyak/performance/utils/ApiResponse.java
@@ -1,0 +1,29 @@
+package com.dayaeyak.performance.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private HttpStatus httpStatus;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(HttpStatus status,T data) {
+        return new ApiResponse<>(status,null,data);
+    }
+
+    public static <T> ApiResponse<T> success(HttpStatus status, String message) {
+        return new ApiResponse<>(status,message,null);
+    }
+
+    public static <T> ApiResponse<T> success(HttpStatus status, String message, T data) {
+        return new ApiResponse<>(status,message,data);
+    }
+
+    public static <T> ApiResponse<T> error(HttpStatus status, String message){
+        return new ApiResponse<>(status, message, null);
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)
공연장(Hall) 생성 API 구현하고, 공통 예외 처리 및 API 응답 표준화 적용했습니다.

## 💫 구현 및 변경 사항 (Details)
- 공연장(Hall) 엔티티 및 공연장 구역(HallSection) 엔티티 생성
- 공연장 생성 API (`POST /halls`) 구현
  - 공연장 및 구역 정보 저장
  - 중복 공연장 이름 예외 처리
- DTO 정의
  - CreateHallRequestDto, CreateHallSectionDto
  - CreateHallResponseDto
- BaseEntity 생성 (생성일/수정일/삭제일 관리)
- 공통 예외 처리 구조 생성
  - CustomException, ErrorCode, GlobalErrorCode
- Hall 전용 예외 코드 생성 (HallErrorCode)
- 글로벌 예외 처리 핸들러(GlobalExceptionHandler) 구현
  - CustomException 처리
  - Validation 예외 처리
- API 응답 표준화 클래스(ApiResponse) 구현

## 📸스크린샷
<img width="603" height="548" alt="화면 캡처 2025-09-09 111845" src="https://github.com/user-attachments/assets/e8c4a5e5-e8bf-4c97-b366-b9b0d1e88989" />

## ✅ 체크리스트
- [x] 코드 정상 작동 테스트 완료
- [x] API 명세서 업데이트
- [x] 팀의 코드 컨벤션 준수
- [x] Reviewers에 팀원 등록

## 💬 TODO ( 미완성일 경우 )
- 권한 확인 로직 추가 필요

## 기타/주의사항