### PR TITLE
feat: Cast 도메인 API 구현

### DIFF
--- a/src/main/java/com/dayaeyak/performance/domain/cast/controller/CastController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/controller/CastController.java
@@ -59,4 +59,12 @@ public class CastController {
                 castService.readCastList(page, size));
     }
 
+    @Operation(summary = "Delete Cast", description = "출연진 정보를 삭제합니다.")
+    @DeleteMapping("/{castId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCast(@PathVariable Long castId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "출연진을 삭제했습니다",
+                castService.deleteCast(castId));
+    }
+
 }

--- a/src/main/java/com/dayaeyak/performance/domain/cast/controller/CastController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/controller/CastController.java
@@ -10,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/cast")
@@ -30,4 +27,15 @@ public class CastController {
                 "출연진이 생성되었습니다",
                 castService.createCast(requestDto));
     }
+
+    @Operation(summary = "Update Cast", description = "기존 출연진의 정보를 수정합니다")
+    @PatchMapping("/{castId}")
+    public ResponseEntity<ApiResponse<CreateCastResponseDto>> updateCast(
+            @PathVariable Long castId,
+            @Validated @RequestBody CreateCastRequestDto requestDto){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "출연진 정보가 수정되었습니다.",
+                castService.updateCast(castId, requestDto));
+    }
+
 }

--- a/src/main/java/com/dayaeyak/performance/domain/cast/controller/CastController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/controller/CastController.java
@@ -1,0 +1,33 @@
+package com.dayaeyak.performance.domain.cast.controller;
+
+import com.dayaeyak.performance.domain.cast.dto.request.CreateCastRequestDto;
+import com.dayaeyak.performance.domain.cast.dto.response.CreateCastResponseDto;
+import com.dayaeyak.performance.domain.cast.service.CastService;
+import com.dayaeyak.performance.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/cast")
+@RequiredArgsConstructor
+@Tag(name = "Cast API")
+public class CastController {
+    private final CastService castService;
+
+    @Operation(summary = "Create Cast", description = "새로운 출연진을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateCastResponseDto>> createCast(
+            @Validated @RequestBody CreateCastRequestDto requestDto) {
+        return ApiResponse.success(HttpStatus.CREATED.value(),
+                "출연진이 생성되었습니다",
+                castService.createCast(requestDto));
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/cast/controller/CastController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/controller/CastController.java
@@ -2,6 +2,7 @@ package com.dayaeyak.performance.domain.cast.controller;
 
 import com.dayaeyak.performance.domain.cast.dto.request.CreateCastRequestDto;
 import com.dayaeyak.performance.domain.cast.dto.response.CreateCastResponseDto;
+import com.dayaeyak.performance.domain.cast.dto.response.ReadCastResponseDto;
 import com.dayaeyak.performance.domain.cast.service.CastService;
 import com.dayaeyak.performance.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/cast")
@@ -36,6 +39,24 @@ public class CastController {
         return ApiResponse.success(HttpStatus.OK.value(),
                 "출연진 정보가 수정되었습니다.",
                 castService.updateCast(castId, requestDto));
+    }
+
+    @Operation(summary = "Read Cast", description = "단건 출연진의 정보를 조회합니다.")
+    @GetMapping("/{castId}")
+    public ResponseEntity<ApiResponse<ReadCastResponseDto>> readCast(@PathVariable Long castId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "출연진 정보를 조회합니다.",
+                castService.readCast(castId));
+    }
+
+    @Operation(summary = "Read Cast List", description = "출연진(기본 정보) 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CreateCastResponseDto>>> readCastList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "출연진 목록을 조회합니다.",
+                castService.readCastList(page, size));
     }
 
 }

--- a/src/main/java/com/dayaeyak/performance/domain/cast/dto/request/CreateCastRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/dto/request/CreateCastRequestDto.java
@@ -1,0 +1,11 @@
+package com.dayaeyak.performance.domain.cast.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCastRequestDto(
+        @Schema(description = "출연진 이름", example = "아이유")
+        @NotBlank(message = "출연진 이름을 입력해주세요.")
+        String castName
+) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/cast/dto/response/CreateCastResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/dto/response/CreateCastResponseDto.java
@@ -1,0 +1,12 @@
+package com.dayaeyak.performance.domain.cast.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateCastResponseDto(
+        @Schema(description = "출연진 ID", example = "1")
+        Long castId,
+
+        @Schema(description = "출연진 이름", example = "아이유")
+        String castName
+) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/cast/dto/response/ReadCastResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/dto/response/ReadCastResponseDto.java
@@ -1,0 +1,17 @@
+package com.dayaeyak.performance.domain.cast.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record ReadCastResponseDto (
+        @Schema(description = "출연진 ID", example = "1")
+        Long castId,
+
+        @Schema(description = "출연진 이름", example = "아이유")
+        String castName,
+
+        @Schema(description = "출연 공연 목록 (공연 ID)")
+        List<Long> performanceList
+){
+}

--- a/src/main/java/com/dayaeyak/performance/domain/cast/entity/Cast.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/entity/Cast.java
@@ -1,0 +1,34 @@
+package com.dayaeyak.performance.domain.cast.entity;
+
+import com.dayaeyak.performance.common.entity.BaseEntity;
+import com.dayaeyak.performance.domain.performance.entity.Performance;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "casts")
+public class Cast extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long castId;
+
+    @Column(length = 30, nullable = false, unique = true)
+    private String castName;
+
+    @ManyToMany(fetch = FetchType.LAZY, mappedBy = "castList")
+    private List<Performance> performanceList = new ArrayList<>();
+
+    public Cast(String castName){
+        this.castName = castName;
+    }
+    public void update(String castName) {
+        this.castName = castName;
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/cast/exception/CastErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/exception/CastErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum CastErrorCode implements ErrorCode {
     CAST_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 출연진 이름이 존재합니다"),
-    CAST_NOT_FOUND(HttpStatus.NOT_FOUND, "출연진 정보를 찾을 수 없습니다");
+    CAST_NOT_FOUND(HttpStatus.NOT_FOUND, "출연진 정보를 찾을 수 없습니다"),
+    CAST_LINKED_PERFORMANCE(HttpStatus.BAD_REQUEST, "출연진과 관련된 공연이 있어 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/dayaeyak/performance/domain/cast/exception/CastErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/exception/CastErrorCode.java
@@ -1,0 +1,16 @@
+package com.dayaeyak.performance.domain.cast.exception;
+
+import com.dayaeyak.performance.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CastErrorCode implements ErrorCode {
+    CAST_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 출연진 이름이 존재합니다"),
+    CAST_NOT_FOUND(HttpStatus.NOT_FOUND, "출연진 정보를 찾을 수 없습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/dayaeyak/performance/domain/cast/repository/CastRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/repository/CastRepository.java
@@ -3,6 +3,10 @@ package com.dayaeyak.performance.domain.cast.repository;
 import com.dayaeyak.performance.domain.cast.entity.Cast;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CastRepository extends JpaRepository<Cast,Long> {
     Boolean existsByCastNameAndDeletedAtIsNull(String castName);
+    Optional<Cast> findByCastIdAndDeletedAtIsNull(Long castId);
+    Boolean existsByCastNameAndCastIdNotAndDeletedAtIsNull(String castName, Long castId);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/cast/repository/CastRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/repository/CastRepository.java
@@ -1,12 +1,17 @@
 package com.dayaeyak.performance.domain.cast.repository;
 
 import com.dayaeyak.performance.domain.cast.entity.Cast;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CastRepository extends JpaRepository<Cast,Long> {
     Boolean existsByCastNameAndDeletedAtIsNull(String castName);
     Optional<Cast> findByCastIdAndDeletedAtIsNull(Long castId);
     Boolean existsByCastNameAndCastIdNotAndDeletedAtIsNull(String castName, Long castId);
+    Page<Cast> findByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
+    List<Cast> findByDeletedAtIsNullOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/dayaeyak/performance/domain/cast/repository/CastRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/repository/CastRepository.java
@@ -1,0 +1,8 @@
+package com.dayaeyak.performance.domain.cast.repository;
+
+import com.dayaeyak.performance.domain.cast.entity.Cast;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CastRepository extends JpaRepository<Cast,Long> {
+    Boolean existsByCastNameAndDeletedAtIsNull(String castName);
+}

--- a/src/main/java/com/dayaeyak/performance/domain/cast/service/CastService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/service/CastService.java
@@ -31,4 +31,22 @@ public class CastService {
         // 응답 DTO 생성 및 반환
         return new CreateCastResponseDto(savedCast.getCastId(), savedCast.getCastName());
     }
+
+    /*출연진 수정*/
+    @Transactional
+    public CreateCastResponseDto updateCast(Long castId, CreateCastRequestDto requestDto) {
+        // 기존 출연진 조회
+        Cast existingCast = castRepository.findByCastIdAndDeletedAtIsNull(castId)
+                .orElseThrow(() -> new CustomException(CastErrorCode.CAST_NOT_FOUND));
+
+        // 출연진 이름 중복 검색 (자신 제외)
+        if(castRepository.existsByCastNameAndCastIdNotAndDeletedAtIsNull(requestDto.castName(), castId)){
+            throw new CustomException(CastErrorCode.CAST_NAME_DUPLICATED);
+        }
+
+        // 출연진 정보 수정
+        existingCast.update(requestDto.castName());
+
+        return new CreateCastResponseDto(existingCast.getCastId(), existingCast.getCastName());
+    }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/cast/service/CastService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/service/CastService.java
@@ -1,0 +1,34 @@
+package com.dayaeyak.performance.domain.cast.service;
+
+import com.dayaeyak.performance.common.exception.CustomException;
+import com.dayaeyak.performance.domain.cast.dto.request.CreateCastRequestDto;
+import com.dayaeyak.performance.domain.cast.dto.response.CreateCastResponseDto;
+import com.dayaeyak.performance.domain.cast.entity.Cast;
+import com.dayaeyak.performance.domain.cast.exception.CastErrorCode;
+import com.dayaeyak.performance.domain.cast.repository.CastRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CastService {
+    private final CastRepository castRepository;
+
+    /*출연진 생성*/
+    @Transactional
+    public CreateCastResponseDto createCast(CreateCastRequestDto requestDto) {
+        // 출연진 이름 중복 검색
+        if(castRepository.existsByCastNameAndDeletedAtIsNull(requestDto.castName())){
+            throw new CustomException(CastErrorCode.CAST_NAME_DUPLICATED);
+        }
+
+        // 출연진 엔티티 생성 및 저장
+        Cast cast = new Cast(requestDto.castName());
+        Cast savedCast = castRepository.save(cast);
+
+        // 응답 DTO 생성 및 반환
+        return new CreateCastResponseDto(savedCast.getCastId(), savedCast.getCastName());
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/cast/service/CastService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/service/CastService.java
@@ -1,14 +1,22 @@
 package com.dayaeyak.performance.domain.cast.service;
 
 import com.dayaeyak.performance.common.exception.CustomException;
+import com.dayaeyak.performance.common.exception.GlobalErrorCode;
 import com.dayaeyak.performance.domain.cast.dto.request.CreateCastRequestDto;
 import com.dayaeyak.performance.domain.cast.dto.response.CreateCastResponseDto;
+import com.dayaeyak.performance.domain.cast.dto.response.ReadCastResponseDto;
 import com.dayaeyak.performance.domain.cast.entity.Cast;
 import com.dayaeyak.performance.domain.cast.exception.CastErrorCode;
 import com.dayaeyak.performance.domain.cast.repository.CastRepository;
+import com.dayaeyak.performance.domain.performance.entity.Performance;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +56,41 @@ public class CastService {
         existingCast.update(requestDto.castName());
 
         return new CreateCastResponseDto(existingCast.getCastId(), existingCast.getCastName());
+    }
+
+    /* 출연진 단건 조회 */
+    public ReadCastResponseDto readCast(Long castId) {
+        // 기존 출연진 조회
+        Cast cast = castRepository.findByCastIdAndDeletedAtIsNull(castId)
+                .orElseThrow(() -> new CustomException(CastErrorCode.CAST_NOT_FOUND));
+
+        // 공연 ID만 추출하여 리스트화
+        List<Long> performanceIdList = cast.getPerformanceList()
+                .stream()
+                .map(Performance::getPerformanceId)
+                .toList();
+
+        // 응답 DTO로 반환
+        return new ReadCastResponseDto(cast.getCastId(), cast.getCastName(), performanceIdList);
+    }
+
+    /* 출연진 목록 조회 */
+    public List<CreateCastResponseDto> readCastList(int page, int size) {
+        if(page < 0 || size < 0){
+            throw new CustomException(GlobalErrorCode.INVALID_PAGE_OR_SIZE);
+        }
+
+        List<Cast> castList;
+        if(size == 0){      // 전체 조회 조건
+            castList = castRepository.findByDeletedAtIsNullOrderByCreatedAtDesc();
+        } else{
+            Pageable pageable = PageRequest.of(page, size);
+            Page<Cast> castPage = castRepository.findByDeletedAtIsNullOrderByCreatedAtDesc(pageable);
+            castList = castPage.getContent();
+        }
+
+        return castList.stream()
+                .map(cast -> new CreateCastResponseDto(cast.getCastId(), cast.getCastName()))
+                .toList();
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
@@ -55,10 +55,10 @@ public class HallController {
     public ResponseEntity<ApiResponse<List<ReadHallResponseDto>>> readHallList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) Region city){
+            @RequestParam(required = false) Region region){
         return ApiResponse.success(HttpStatus.OK.value(),
                 "공연장 목록을 조회합니다.",
-                hallService.readHallList(page, size, city));
+                hallService.readHallList(page, size, region));
     }
 
     @Operation(summary = "Delete Hall", description = "공연장 정보를 삭제합니다.")

--- a/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/HallController.java
@@ -50,9 +50,9 @@ public class HallController {
                 hallService.readHall(hallId));
     }
 
-    @Operation(summary = "Read Hall", description = "공연장(기본 정보) 목록을 조회합니다.")
+    @Operation(summary = "Read Hall List", description = "공연장(기본 정보) 목록을 조회합니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<ReadHallResponseDto>>> readHall(
+    public ResponseEntity<ApiResponse<List<ReadHallResponseDto>>> readHallList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) Region city){

--- a/src/main/java/com/dayaeyak/performance/domain/hall/HallService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/HallService.java
@@ -41,7 +41,7 @@ public class HallService {
         Hall hall = Hall.builder()
                 .hallName(requestDto.hallName())
                 .address(requestDto.address())
-                .city(requestDto.city())
+                .region(requestDto.region())
                 .capacity(requestDto.capacity())
                 .build();
         Hall savedHall = hallRepository.save(hall);
@@ -67,7 +67,7 @@ public class HallService {
         }
 
         // 공연장 정보 수정
-        existingHall.update(requestDto.hallName(), requestDto.address(), requestDto.city(), requestDto.capacity());
+        existingHall.update(requestDto.hallName(), requestDto.address(), requestDto.region(), requestDto.capacity());
 
         // 구역 정보가 있으면 기존 구역 삭제 후 새로 저장
         if(requestDto.sections() != null && !requestDto.sections().isEmpty()) {
@@ -90,23 +90,23 @@ public class HallService {
     }
 
     /* 공연장 목록 조회 */
-    public List<ReadHallResponseDto> readHallList(int page, int size, Region city) {
+    public List<ReadHallResponseDto> readHallList(int page, int size, Region region) {
         if(page < 0 || size < 0){
             throw new CustomException(GlobalErrorCode.INVALID_PAGE_OR_SIZE);
         }
 
         List<Hall> halls;
         if(size == 0){
-            if(city != null){       // 지역별 전체 공연장 목록 조회
-                halls = hallRepository.findByCityAndDeletedAtIsNullOrderByCreatedAtDesc(city);
+            if(region != null){       // 지역별 전체 공연장 목록 조회
+                halls = hallRepository.findByRegionAndDeletedAtIsNullOrderByCreatedAtDesc(region);
             } else{                 // 전체 공연장 목록 조회
                 halls = hallRepository.findByDeletedAtIsNullOrderByCreatedAtDesc();
             }
         } else{
             Pageable pageable = PageRequest.of(page, size);
             Page<Hall> hallPage;
-            if (city != null) {     // 지역별 공연장 페이징 조회
-                hallPage = hallRepository.findByCityAndDeletedAtIsNullOrderByCreatedAtDesc(city, pageable);
+            if (region != null) {     // 지역별 공연장 페이징 조회
+                hallPage = hallRepository.findByRegionAndDeletedAtIsNullOrderByCreatedAtDesc(region, pageable);
             } else {                // 공연장 페이징 조회
                 hallPage = hallRepository.findByDeletedAtIsNullOrderByCreatedAtDesc(pageable);
             }
@@ -118,7 +118,7 @@ public class HallService {
                         hall.getHallId(),
                         hall.getHallName(),
                         hall.getAddress(),
-                        hall.getCity(),
+                        hall.getRegion(),
                         hall.getCapacity()))
                 .toList();
     }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallRequestDto.java
@@ -21,7 +21,7 @@ public record CreateHallRequestDto(
 
         @Schema(description = "공연장 소재 지역", example = "SEOUL")
         @NotNull(message = "공연장이 위치한 지역을 입력해주세요.")
-        Region city,
+        Region region,
 
         @Schema(description = "수용 인원", example = "12000")
         @NotNull(message = "공연장의 수용인원을 입력해주세요.")

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/UpdateHallRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/UpdateHallRequestDto.java
@@ -20,7 +20,7 @@ public record UpdateHallRequestDto(
 
         @Schema(description = "공연장 소재 지역", example = "SEOUL")
         @NotNull(message = "공연장이 위치한 지역을 입력해주세요.")
-        Region city,
+        Region region,
 
         @Schema(description = "수용 인원", example = "12000")
         @NotNull(message = "공연장의 수용인원을 입력해주세요.")

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/ReadHallResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/ReadHallResponseDto.java
@@ -17,7 +17,7 @@ public record ReadHallResponseDto(
         String address,
 
         @Schema(description = "공연장 소재 지역", example = "SEOUL")
-        Region city,
+        Region region,
 
         @Schema(description = "수용 인원", example = "12000")
         Integer capacity
@@ -28,7 +28,7 @@ public record ReadHallResponseDto(
                 .hallId(hall.getHallId())
                 .hallName(hall.getHallName())
                 .address(hall.getAddress())
-                .city(hall.getCity())
+                .region(hall.getRegion())
                 .capacity(hall.getCapacity())
                 .build();
 

--- a/src/main/java/com/dayaeyak/performance/domain/hall/entity/Hall.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/entity/Hall.java
@@ -25,23 +25,23 @@ public class Hall extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Region city;
+    private Region region;
 
     @Column(nullable = false)
     private Integer capacity;
 
     @Builder
-    public Hall(String hallName, String address, Region city, Integer capacity) {
+    public Hall(String hallName, String address, Region region, Integer capacity) {
         this.hallName = hallName;
         this.address = address;
-        this.city = city;
+        this.region = region;
         this.capacity = capacity;
     }
 
-    public void update(String hallName, String address, Region city, Integer capacity) {
+    public void update(String hallName, String address, Region region, Integer capacity) {
         this.hallName = hallName;
         this.address = address;
-        this.city = city;
+        this.region = region;
         this.capacity = capacity;
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/enums/MinimumAge.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/enums/MinimumAge.java
@@ -1,0 +1,13 @@
+package com.dayaeyak.performance.domain.hall.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MinimumAge {
+    ALL("전체 관람가"),
+    R15("15세 이상 관람가"),
+    R18("18세 이상 관람가");
+    private final String minimumAge;
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/enums/Region.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/enums/Region.java
@@ -20,5 +20,5 @@ public enum Region {
     BUSAN("부산"),
     JEJU("제주");
 
-    private final String city;
+    private final String region;
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/repository/HallRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/repository/HallRepository.java
@@ -13,8 +13,8 @@ public interface HallRepository extends JpaRepository<Hall,Long> {
     Boolean existsByHallNameAndDeletedAtIsNull(String hallName);
     Boolean existsByHallNameAndHallIdNotAndDeletedAtIsNull(String hallName, Long hallId);
     Optional<Hall> findByHallIdAndDeletedAtIsNull(Long hallId);
-    Page<Hall> findByCityAndDeletedAtIsNullOrderByCreatedAtDesc(Region city, Pageable pageable);
-    List<Hall> findByCityAndDeletedAtIsNullOrderByCreatedAtDesc(Region city);
+    Page<Hall> findByRegionAndDeletedAtIsNullOrderByCreatedAtDesc(Region region, Pageable pageable);
+    List<Hall> findByRegionAndDeletedAtIsNullOrderByCreatedAtDesc(Region region);
     Page<Hall> findByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
     List<Hall> findByDeletedAtIsNullOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/entity/Performance.java
@@ -1,0 +1,70 @@
+package com.dayaeyak.performance.domain.performance.entity;
+
+import com.dayaeyak.performance.common.entity.BaseEntity;
+import com.dayaeyak.performance.domain.cast.entity.Cast;
+import com.dayaeyak.performance.domain.hall.entity.Hall;
+import com.dayaeyak.performance.domain.hall.enums.MinimumAge;
+import com.dayaeyak.performance.domain.performance.enums.Type;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "performances")
+public class Performance extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long performanceId;
+
+    @Column(nullable = false)
+    private Long sellerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hall_id", nullable = false)
+    private Hall hall;
+
+    @Column(length = 100, nullable = false)
+    private String performanceName;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private Type type;
+
+    @Column(nullable = false)
+    private MinimumAge minimumAge;
+
+    @Column(nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date startDate;
+
+    @Column(nullable = false)
+    @Temporal(TemporalType.DATE)
+    private Date endDate;
+
+    @Column(nullable = false)
+    private Timestamp ticketOpen;
+
+    @Column(nullable = false)
+    private Timestamp ticketClose;
+
+    @Column(nullable = false)
+    private Boolean isActivated;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "performance_cast",
+            joinColumns = @JoinColumn(name = "performance_id"),
+            inverseJoinColumns = @JoinColumn(name = "cast_id")
+    )
+    private List<Cast> castList = new ArrayList<>();
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/entity/Performance.java
@@ -3,7 +3,7 @@ package com.dayaeyak.performance.domain.performance.entity;
 import com.dayaeyak.performance.common.entity.BaseEntity;
 import com.dayaeyak.performance.domain.cast.entity.Cast;
 import com.dayaeyak.performance.domain.hall.entity.Hall;
-import com.dayaeyak.performance.domain.hall.enums.MinimumAge;
+import com.dayaeyak.performance.domain.performance.enums.Grade;
 import com.dayaeyak.performance.domain.performance.enums.Type;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -41,7 +41,7 @@ public class Performance extends BaseEntity {
     private Type type;
 
     @Column(nullable = false)
-    private MinimumAge minimumAge;
+    private Grade grade;
 
     @Column(nullable = false)
     @Temporal(TemporalType.DATE)
@@ -52,10 +52,10 @@ public class Performance extends BaseEntity {
     private Date endDate;
 
     @Column(nullable = false)
-    private Timestamp ticketOpen;
+    private Timestamp ticketOpenAt;
 
     @Column(nullable = false)
-    private Timestamp ticketClose;
+    private Timestamp ticketCloseAt;
 
     @Column(nullable = false)
     private Boolean isActivated;

--- a/src/main/java/com/dayaeyak/performance/domain/performance/enums/Grade.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/enums/Grade.java
@@ -1,13 +1,13 @@
-package com.dayaeyak.performance.domain.hall.enums;
+package com.dayaeyak.performance.domain.performance.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum MinimumAge {
+public enum Grade {
     ALL("전체 관람가"),
     R15("15세 이상 관람가"),
     R18("18세 이상 관람가");
-    private final String minimumAge;
+    private final String grade;
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/enums/Type.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/enums/Type.java
@@ -1,0 +1,14 @@
+package com.dayaeyak.performance.domain.performance.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Type {
+    CONCERT("콘서트"),
+    MUSICAL("뮤지컬"),
+    PLAY("연극");
+
+    private final String type;
+}


### PR DESCRIPTION
## 📝 요약(Summary)
출연진(Cast) 도메인 생성하고 CRUD 구현했습니다.
컬럼명도 수정하고 ERD 업데이트했어요!

## 💫 구현 및 변경 사항 (Details)
- 출연진 생성 API
- 출연진 수정 API 
- 출연진 단건 조회 API
  - 관련 공연 정보 포함 (공연 ID 리스트)
- 출연진 목록 조회 API
  - `?size=0` : 전체 조회
  - 관련 공연 정보 미포함
- 출연진 삭제 API
  - 관련 공연 있으면 삭제 불가

## ✅ 체크리스트
- [x] 코드 정상 작동 테스트 완료
- [x] API 명세서 업데이트
- [x] 팀의 코드 컨벤션 준수
- [x] Reviewers에 팀원 등록

## 💬 TODO ( 미완성일 경우 )
- 권한 확인 로직 추가 필요

## 기타/주의사항