### PR TITLE
feat: 공연장 구역 API 구현

### DIFF
--- a/src/main/java/com/dayaeyak/performance/common/dto/PageInfoDto.java
+++ b/src/main/java/com/dayaeyak/performance/common/dto/PageInfoDto.java
@@ -1,6 +1,7 @@
 package com.dayaeyak.performance.common.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
 
 public record PageInfoDto(
         @Schema(description = "현재 페이지 번호", example = "1")
@@ -17,4 +18,14 @@ public record PageInfoDto(
 
         @Schema(description = "마지막 페이지 여부", example = "false")
         boolean last) {
+
+        public static PageInfoDto from(Page<?> page) {
+                return new PageInfoDto(
+                        page.getNumber() + 1,
+                        page.getSize(),
+                        page.getTotalElements(),
+                        page.getTotalPages(),
+                        page.isLast()
+                );
+        }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/cast/dto/request/CreateCastRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/dto/request/CreateCastRequestDto.java
@@ -2,10 +2,12 @@ package com.dayaeyak.performance.domain.cast.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record CreateCastRequestDto(
         @Schema(description = "출연진 이름", example = "아이유")
         @NotBlank(message = "출연진 이름을 입력해주세요.")
+        @Size(max = 30, message = "출연진 이름은 30자까지 입력 가능합니다.")
         String castName
 ) {
 }

--- a/src/main/java/com/dayaeyak/performance/domain/cast/entity/Cast.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/entity/Cast.java
@@ -21,7 +21,7 @@ public class Cast extends BaseEntity {
     @Column(nullable = false, updatable = false)
     private Long castId;
 
-    @Column(length = 30, nullable = false, unique = true)
+    @Column(length = 30, nullable = false)
     private String castName;
 
     @ManyToMany(fetch = FetchType.LAZY, mappedBy = "castList")

--- a/src/main/java/com/dayaeyak/performance/domain/cast/service/CastService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/cast/service/CastService.java
@@ -88,13 +88,7 @@ public class CastService {
         Page<Cast> castPage = castRepository.findByDeletedAtIsNull(pageable);
 
         // PageInfo 생성
-        PageInfoDto pageInfo = new PageInfoDto(
-                castPage.getNumber() + 1, // 0-base -> 1-base
-                castPage.getSize(),
-                castPage.getTotalElements(),
-                castPage.getTotalPages(),
-                castPage.isLast()
-        );
+        PageInfoDto pageInfo = PageInfoDto.from(castPage);
 
         List<ReadCastResponseDto> data = castPage.getContent()
                 .stream()

--- a/src/main/java/com/dayaeyak/performance/domain/hall/controller/HallSectionController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/controller/HallSectionController.java
@@ -1,0 +1,32 @@
+package com.dayaeyak.performance.domain.hall.controller;
+
+import com.dayaeyak.performance.domain.hall.dto.request.CreateHallSectionDto;
+import com.dayaeyak.performance.domain.hall.dto.response.UpdateHallSectionResponseDto;
+import com.dayaeyak.performance.domain.hall.service.HallSectionService;
+import com.dayaeyak.performance.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/halls/{hallId}/sections")
+@RequiredArgsConstructor
+@Tag(name = "Hall Section API")
+public class HallSectionController {
+    private final HallSectionService hallSectionService;
+
+    @Operation(summary = "Update Hall Section", description = "공연장 구역 정보를 수정합니다.")
+    @PutMapping("/{hallSectionId}")
+    public ResponseEntity<ApiResponse<UpdateHallSectionResponseDto>> updateHallSection(
+            @PathVariable Long hallId,
+            @PathVariable Long hallSectionId,
+            @Validated @RequestBody CreateHallSectionDto requestDto){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "공연장 구역 정보가 수정되었습니다.",
+                hallSectionService.updateHallSection(hallId, hallSectionId, requestDto));
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/controller/HallSectionController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/controller/HallSectionController.java
@@ -1,6 +1,7 @@
 package com.dayaeyak.performance.domain.hall.controller;
 
 import com.dayaeyak.performance.domain.hall.dto.request.CreateHallSectionDto;
+import com.dayaeyak.performance.domain.hall.dto.response.ReadHallSectionResponseDto;
 import com.dayaeyak.performance.domain.hall.dto.response.UpdateHallSectionResponseDto;
 import com.dayaeyak.performance.domain.hall.service.HallSectionService;
 import com.dayaeyak.performance.utils.ApiResponse;
@@ -11,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/halls/{hallId}/sections")
@@ -28,5 +31,24 @@ public class HallSectionController {
         return ApiResponse.success(HttpStatus.OK.value(),
                 "공연장 구역 정보가 수정되었습니다.",
                 hallSectionService.updateHallSection(hallId, hallSectionId, requestDto));
+    }
+
+    @Operation(summary = "Read Hall Section", description = "공연장의 단건 구역 정보를 조회합니다.")
+    @GetMapping("/{hallSectionId}")
+    public ResponseEntity<ApiResponse<ReadHallSectionResponseDto>> readHallSection(
+            @PathVariable Long hallId,
+            @PathVariable Long hallSectionId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "공연장 구역 정보를 조회합니다.",
+                hallSectionService.readHallSection(hallId, hallSectionId));
+    }
+
+    @Operation(summary = "Read All Hall Sections", description = "공연장의 전체 구역 정보를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ReadHallSectionResponseDto>>> readHallSections(
+            @PathVariable Long hallId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "해당 공연장의 전체 구역을 조회합니다.",
+                hallSectionService.readHallSections(hallId));
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallRequestDto.java
@@ -3,20 +3,19 @@ package com.dayaeyak.performance.domain.hall.dto.request;
 import com.dayaeyak.performance.domain.hall.enums.Region;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 import java.util.List;
 
 public record CreateHallRequestDto(
         @Schema(description = "공연장 이름", example = "KSPO DOME")
         @NotBlank(message = "공연장 이름은 필수 입력값입니다.")
+        @Size(max = 100, message = "공연장 이름은 100자까지 입력 가능합니다.")
         String hallName,
 
         @Schema(description = "공연장 주소", example = "서울특별시 송파구 올림픽로 424")
         @NotBlank(message = "공연장 주소는 필수 입력값입니다.")
+        @Size(max = 100, message = "공연장 주소는 100자까지 입력 가능합니다.")
         String address,
 
         @Schema(description = "공연장 소재 지역", example = "SEOUL")

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallSectionDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallSectionDto.java
@@ -4,10 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record CreateHallSectionDto(
         @Schema(description = "구역 이름", example = "101")
         @NotBlank(message = "구역 이름은 필수 입력값입니다.")
+        @Size(max = 50, message = "구역 이름은 50자까지 입력 가능합니다.")
         String sectionName,
 
         @Schema(description = "구역의 좌석수", example = "300")

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/UpdateHallRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/UpdateHallRequestDto.java
@@ -6,16 +6,19 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record UpdateHallRequestDto(
         @Schema(description = "공연장 이름", example = "KSPO DOME")
         @NotBlank(message = "공연장 이름은 필수 입력값입니다.")
+        @Size(max = 100, message = "공연장 이름은 100자까지 입력 가능합니다.")
         String hallName,
 
         @Schema(description = "공연장 주소", example = "서울특별시 송파구 올림픽로 424")
         @NotBlank(message = "공연장 주소는 필수 입력값입니다.")
+        @Size(max = 100, message = "공연장 주소는 100자까지 입력 가능합니다.")
         String address,
 
         @Schema(description = "공연장 소재 지역", example = "SEOUL")

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/ReadHallSectionResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/ReadHallSectionResponseDto.java
@@ -1,0 +1,21 @@
+package com.dayaeyak.performance.domain.hall.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReadHallSectionResponseDto(
+        @Schema(description = "소속된 공연장 ID", example = "2")
+        Long hallId,
+
+        @Schema(description = "공연장 구역 ID", example = "1")
+        Long hallSectionId,
+
+        @Schema(description = "구역 이름", example = "101")
+        String sectionName,
+
+        @Schema(description = "구역의 좌석수", example = "300")
+        Integer seats,
+
+        @Schema(description = "좌석당 가격", example = "156000")
+        Integer seatPrice
+) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/UpdateHallSectionResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/UpdateHallSectionResponseDto.java
@@ -1,0 +1,9 @@
+package com.dayaeyak.performance.domain.hall.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateHallSectionResponseDto(
+        @Schema(description = "공연장 구역 ID", example = "1")
+        Long hallSectionId
+) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/entity/Hall.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/entity/Hall.java
@@ -18,7 +18,7 @@ public class Hall extends BaseEntity {
     @Column(nullable = false, updatable = false)
     private Long hallId;
 
-    @Column(length = 100, nullable = false, unique = true)
+    @Column(length = 100, nullable = false)
     private String hallName;
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/com/dayaeyak/performance/domain/hall/entity/HallSection.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/entity/HallSection.java
@@ -37,4 +37,10 @@ public class HallSection extends BaseEntity {
         this.seats = seats;
         this.seatPrice = seatPrice;
     }
+
+    public void update(String sectionName, Integer seats, Integer seatPrice) {
+        this.sectionName = sectionName;
+        this.seats = seats;
+        this.seatPrice = seatPrice;
+    }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/exception/HallErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/exception/HallErrorCode.java
@@ -13,7 +13,8 @@ public enum HallErrorCode implements ErrorCode {
     HALL_NOT_FOUND(HttpStatus.NOT_FOUND, "공연장 정보를 찾을 수 없습니다."),
     HALL_SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "공연장 구역 정보를 찾을 수 없습니다."),
     HALL_ID_MISMATCH(HttpStatus.BAD_REQUEST, "공연 구역 ID가 소속된 공연장 ID를 입력해주세요."),
-    CANNOT_DELETE_HALL(HttpStatus.BAD_REQUEST, "연결된 공연이 있어 공연장을 삭제할 수 없습니다.");
+    CANNOT_DELETE_HALL(HttpStatus.BAD_REQUEST, "연결된 공연이 있어 공연장을 삭제할 수 없습니다."),
+    CANNOT_UPDATE_HALL(HttpStatus.BAD_REQUEST, "진행 중인 공연이 있어 공연장을 수정할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/dayaeyak/performance/domain/hall/exception/HallErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/exception/HallErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum HallErrorCode implements ErrorCode {
     HALL_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "중복된 공연장 이름이 존재합니다."),
+    HALL_SECTION_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "같은 공연장 내 중복된 구역 이름이 존재합니다."),
     HALL_NOT_FOUND(HttpStatus.NOT_FOUND, "공연장 정보를 찾을 수 없습니다."),
+    HALL_SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "공연장 구역 정보를 찾을 수 없습니다."),
+    HALL_ID_MISMATCH(HttpStatus.BAD_REQUEST, "공연 구역 ID가 소속된 공연장 ID를 입력해주세요."),
     CANNOT_DELETE_HALL(HttpStatus.BAD_REQUEST, "연결된 공연이 있어 공연장을 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dayaeyak/performance/domain/hall/repository/HallSectionRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/repository/HallSectionRepository.java
@@ -5,8 +5,11 @@ import com.dayaeyak.performance.domain.hall.entity.HallSection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface HallSectionRepository extends JpaRepository<HallSection, Long> {
     void deleteByHall(Hall hall);
     List<HallSection> findByHallAndDeletedAtIsNull(Hall hall);
+    Optional<HallSection> findByHallSectionIdAndDeletedAtIsNull(Long hallSectionId);
+    Boolean existsByHall_HallIdAndSectionNameAndHallSectionIdNotAndDeletedAtIsNull(Long hallId, String sectionName, Long hallSectionId);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/service/HallSectionService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/service/HallSectionService.java
@@ -1,0 +1,44 @@
+package com.dayaeyak.performance.domain.hall.service;
+
+import com.dayaeyak.performance.common.exception.CustomException;
+import com.dayaeyak.performance.domain.hall.dto.request.CreateHallSectionDto;
+import com.dayaeyak.performance.domain.hall.dto.response.UpdateHallSectionResponseDto;
+import com.dayaeyak.performance.domain.hall.entity.HallSection;
+import com.dayaeyak.performance.domain.hall.exception.HallErrorCode;
+import com.dayaeyak.performance.domain.hall.repository.HallRepository;
+import com.dayaeyak.performance.domain.hall.repository.HallSectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HallSectionService {
+    private final HallSectionRepository hallSectionRepository;
+    private final HallRepository hallRepository;
+
+    /* 공연장 구역 수정 */
+    @Transactional
+    public UpdateHallSectionResponseDto updateHallSection(Long hallId, Long hallSectionId, CreateHallSectionDto requestDto) {
+        // 구역 ID로 조회
+        HallSection hallSection = hallSectionRepository.findByHallSectionIdAndDeletedAtIsNull(hallSectionId)
+                .orElseThrow(() -> new CustomException(HallErrorCode.HALL_SECTION_NOT_FOUND));
+
+        // 조회된 구역의 공연장 ID와 입력된 hallId 비교
+        if (!hallSection.getHall().getHallId().equals(hallId)) {
+            throw new CustomException(HallErrorCode.HALL_ID_MISMATCH);
+        }
+
+        // 같은 공연장 내 중복되는 이름이 있는지 확인 (자기 자신 제외)
+        if (hallSectionRepository.existsByHall_HallIdAndSectionNameAndHallSectionIdNotAndDeletedAtIsNull(
+                hallId, requestDto.sectionName(), hallSectionId)) {
+            throw new CustomException(HallErrorCode.HALL_SECTION_NAME_DUPLICATED);
+        }
+
+        // 구역 정보 수정
+        hallSection.update(requestDto.sectionName(), requestDto.seats(), requestDto.seatPrice());
+
+        return new UpdateHallSectionResponseDto(hallSectionId);
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/service/HallSectionService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/service/HallSectionService.java
@@ -2,7 +2,9 @@ package com.dayaeyak.performance.domain.hall.service;
 
 import com.dayaeyak.performance.common.exception.CustomException;
 import com.dayaeyak.performance.domain.hall.dto.request.CreateHallSectionDto;
+import com.dayaeyak.performance.domain.hall.dto.response.ReadHallSectionResponseDto;
 import com.dayaeyak.performance.domain.hall.dto.response.UpdateHallSectionResponseDto;
+import com.dayaeyak.performance.domain.hall.entity.Hall;
 import com.dayaeyak.performance.domain.hall.entity.HallSection;
 import com.dayaeyak.performance.domain.hall.exception.HallErrorCode;
 import com.dayaeyak.performance.domain.hall.repository.HallRepository;
@@ -10,6 +12,8 @@ import com.dayaeyak.performance.domain.hall.repository.HallSectionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -40,5 +44,41 @@ public class HallSectionService {
         hallSection.update(requestDto.sectionName(), requestDto.seats(), requestDto.seatPrice());
 
         return new UpdateHallSectionResponseDto(hallSectionId);
+    }
+
+    /* 공연장 구역 단건 조회*/
+    public ReadHallSectionResponseDto readHallSection(Long hallId, Long hallSectionId) {
+        // 구역 ID로 조회
+        HallSection hallSection = hallSectionRepository.findByHallSectionIdAndDeletedAtIsNull(hallSectionId)
+                .orElseThrow(() -> new CustomException(HallErrorCode.HALL_SECTION_NOT_FOUND));
+
+        // 조회된 구역의 공연장 ID와 입력된 hallId 비교
+        if (!hallSection.getHall().getHallId().equals(hallId)) {
+            throw new CustomException(HallErrorCode.HALL_ID_MISMATCH);
+        }
+
+        return new ReadHallSectionResponseDto(hallId, hallSectionId,
+                hallSection.getSectionName(), hallSection.getSeats(), hallSection.getSeatPrice());
+    }
+
+    /* 공연장 구역 전체 조회 */
+    public List<ReadHallSectionResponseDto> readHallSections(Long hallId) {
+        // 공연장 조회
+        Hall hall = hallRepository.findByHallIdAndDeletedAtIsNull(hallId)
+                .orElseThrow(() -> new CustomException(HallErrorCode.HALL_NOT_FOUND));
+
+        // 해당 공연장의 전체 구역 조회
+        List<HallSection> hallSections = hallSectionRepository.findByHallAndDeletedAtIsNull(hall);
+
+        // 응답 DTO로 반환
+        return hallSections.stream()
+                .map(section -> new ReadHallSectionResponseDto(
+                        section.getHall().getHallId(),
+                        section.getHallSectionId(),
+                        section.getSectionName(),
+                        section.getSeats(),
+                        section.getSeatPrice()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/service/HallService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/service/HallService.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -69,6 +70,11 @@ public class HallService {
         // 공연장 이름 중복 검색 (자기 자신 제외)
         if (hallRepository.existsByHallNameAndHallIdNotAndDeletedAtIsNull(requestDto.hallName(), hallId)) {
             throw new CustomException(HallErrorCode.HALL_NAME_DUPLICATED);
+        }
+
+        // 관련 공연이 있는지 확인
+        if(performanceRepository.existsByHallAndEndDateGreaterThanEqualAndDeletedAtIsNull(existingHall, LocalDate.now())){
+            throw new CustomException(HallErrorCode.CANNOT_UPDATE_HALL);
         }
 
         // 공연장 정보 수정

--- a/src/main/java/com/dayaeyak/performance/domain/hall/service/HallService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/service/HallService.java
@@ -117,13 +117,7 @@ public class HallService {
         }
 
         // PageInfo 생성
-        PageInfoDto pageInfo = new PageInfoDto(
-                halls.getNumber() + 1, // 0-base -> 1-base
-                halls.getSize(),
-                halls.getTotalElements(),
-                halls.getTotalPages(),
-                halls.isLast()
-        );
+        PageInfoDto pageInfo = PageInfoDto.from(halls);
 
         List<ReadHallResponseDto> data = halls.getContent()
                 .stream()

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/CreatePerformanceRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/CreatePerformanceRequestDto.java
@@ -24,7 +24,7 @@ public record CreatePerformanceRequestDto(
         @NotNull(message = "공연장 ID는 필수 입력값입니다.")
         Long hallId,
 
-        @Schema(description = "출연진 목록", example = "아이유, 박효신, NCT 127")
+        @Schema(description = "출연진 목록", example = "아이유,박효신,NCT 127")
         @NotBlank(message = "출연진 목록은 필수 입력값입니다.")
         String castList,
 

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/CreatePerformanceRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/CreatePerformanceRequestDto.java
@@ -5,6 +5,7 @@ import com.dayaeyak.performance.domain.performance.enums.Type;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -16,6 +17,7 @@ public record CreatePerformanceRequestDto(
 
         @Schema(description = "공연 이름", example = "오페라의 유령")
         @NotBlank(message = "공연 이름은 필수 입력값입니다.")
+        @Size(max = 100, message = "공연 이름은 100자까지 입력 가능합니다.")
         String performanceName,
 
         @Schema(description = "공연장 ID", example = "4")
@@ -28,6 +30,7 @@ public record CreatePerformanceRequestDto(
 
         @Schema(description = "공연 설명", example = "이거완전쩔어용")
         @NotBlank(message = "공연 설명은 필수 입력값입니다.")
+        @Size(max = 255, message = "공연 설명은 255자까지 입력 가능합니다.")
         String description,
 
         @Schema(description = "공연 타입", example = "MUSICAL")

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/UpdatePerformanceRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/UpdatePerformanceRequestDto.java
@@ -16,7 +16,7 @@ public record UpdatePerformanceRequestDto(
         @Schema(description = "공연장 ID", example = "4")
         Long hallId,
 
-        @Schema(description = "출연진 목록", example = "아이유, 박효신, NCT 127")
+        @Schema(description = "출연진 목록", example = "아이유,박효신,NCT 127")
         String castList,
 
         @Schema(description = "공연 설명", example = "이거완전쩔어용")

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/UpdatePerformanceRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/UpdatePerformanceRequestDto.java
@@ -3,12 +3,14 @@ package com.dayaeyak.performance.domain.performance.dto.request;
 import com.dayaeyak.performance.domain.performance.enums.Grade;
 import com.dayaeyak.performance.domain.performance.enums.Type;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record UpdatePerformanceRequestDto(
         @Schema(description = "공연 이름", example = "오페라의 유령")
+        @Size(max = 100, message = "공연 이름은 100자까지 입력 가능합니다.")
         String performanceName,
 
         @Schema(description = "공연장 ID", example = "4")
@@ -18,6 +20,7 @@ public record UpdatePerformanceRequestDto(
         String castList,
 
         @Schema(description = "공연 설명", example = "이거완전쩔어용")
+        @Size(max = 255, message = "공연 설명은 255자까지 입력 가능합니다.")
         String description,
 
         @Schema(description = "공연 타입", example = "MUSICAL")

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/ReadPerformanceResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/ReadPerformanceResponseDto.java
@@ -24,7 +24,7 @@ public record ReadPerformanceResponseDto(
         @Schema(description = "공연장 ID", example = "4")
         Long hallId,
 
-        @Schema(description = "출연진 목록", example = "아이유, 박효신, NCT 127")
+        @Schema(description = "출연진 목록", example = "아이유,박효신,NCT 127")
         List<CastDto> castList,
 
         @Schema(description = "공연 설명", example = "이거완전쩔어용")

--- a/src/main/java/com/dayaeyak/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/entity/Performance.java
@@ -16,7 +16,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "performances")
 public class Performance extends BaseEntity {
@@ -94,5 +93,45 @@ public class Performance extends BaseEntity {
         this.ticketOpenAt = ticketOpenAt;
         this.ticketCloseAt = ticketCloseAt;
         this.isActivated = isActivated;
+    }
+
+    public void updatePerformanceName(String name) {
+        this.performanceName = name;
+    }
+
+    public void changeHall(Hall hall) {
+        this.hall = hall;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updateType(Type type) {
+        this.type = type;
+    }
+
+    public void updateGrade(Grade grade) {
+        this.grade = grade;
+    }
+
+    public void updateStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+    public void updateEndDate(Date endDate) {
+        this.endDate = endDate;
+    }
+
+    public void updateTicketOpenAt(Timestamp ticketOpenAt) {
+        this.ticketOpenAt = ticketOpenAt;
+    }
+
+    public void updateTicketCloseAt(Timestamp ticketCloseAt) {
+        this.ticketCloseAt = ticketCloseAt;
+    }
+
+    public void updateActivation(Boolean activation) {
+        this.isActivated = activation;
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum PerformanceErrorCode implements ErrorCode {
     PERFORMANCE_ALREADY_OPENED(HttpStatus.BAD_REQUEST, "해당 공연의 예매가 이미 시작되어서 수정이 불가합니다."),
     CANNOT_CHANGE_ACTIVATION(HttpStatus.BAD_REQUEST, "지금은 공연의 활성화 상태를 변경할 수 없습니다."),
-    PERFORMANCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "공연 정보를 찾을 수 없습니다.");
+    PERFORMANCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "공연 정보를 찾을 수 없습니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "공연 시작일과 종료일의 범위가 올바르지 않습니다."),
+    INVALID_TICKET_TIME_RANGE(HttpStatus.BAD_REQUEST, "티켓오픈일시와 마감일시의 범위가 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface PerformanceRepository extends JpaRepository<Performance,Long> {
@@ -15,4 +16,5 @@ public interface PerformanceRepository extends JpaRepository<Performance,Long> {
     Page<Performance> findByDeletedAtIsNullAndIsActivatedIsTrue(Pageable pageable);
     Page<Performance> findByDeletedAtIsNullAndTypeAndIsActivatedIsTrue(Pageable pageable, Type type);
     boolean existsByHallAndDeletedAtIsNull(Hall hall);
+    Boolean existsByHallAndEndDateGreaterThanEqualAndDeletedAtIsNull(Hall hall, LocalDate now);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceService.java
@@ -189,13 +189,7 @@ public class PerformanceService {
         }
 
         // PageInfo 생성
-        PageInfoDto pageInfo = new PageInfoDto(
-                performances.getNumber() + 1, // 0-base -> 1-base
-                performances.getSize(),
-                performances.getTotalElements(),
-                performances.getTotalPages(),
-                performances.isLast()
-        );
+        PageInfoDto pageInfo = PageInfoDto.from(performances);
 
         // List<DTO> 형태로 변환
         List<ReadPerformanceResponseDto> data = performances.getContent()


### PR DESCRIPTION
## 📝 요약(Summary)
공연장 구역 API는 수정, 조회만 만들었어요! 공연장 API에서 구역 전체적으로 생성/수정이 가능하기도 하고, 생성/삭제는 할 일이 많이 없을 것 같아서 일단 뺐습니다.

## 💫 구현 및 변경 사항 (Details)
- 공연장 구역 수정 API
  - 수정 시 동일 공연장 내 중복 구역 이름 예외 처리
- 공연장 구역 조회 API
  - 단건 및 전체 조회만 가능
- DTO의 String 필드에 크기 검증 적용
- 공연장 수정 시 제한 조건 추가
  - 아직 종료되지 않은 관련 공연이 있을 경우 예외 처리


## ✅ 체크리스트
- [x] 코드 정상 작동 테스트 완료
- [x] API 명세서 업데이트
- [x] 팀의 코드 컨벤션 준수
- [x] Reviewers에 팀원 등록

## 💬 TODO ( 미완성일 경우 )
- 권한 확인 로직 추가 필요

## 기타/주의사항
PR #4 피드백 주신 사항 반영했습니다!