### PR TITLE
feat: 공연 회차 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.41.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'

--- a/src/main/java/com/dayaeyak/performance/config/RedisConfig.java
+++ b/src/main/java/com/dayaeyak/performance/config/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.dayaeyak.performance.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.redis.port:6379}")
+    private int redisPort;
+
+    @Value("${spring.redis.password:}")
+    private String redisPassword;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+
+        // Redis 서버 설정
+        String address = String.format("redis://%s:%d", redisHost, redisPort);
+
+        if (redisPassword != null && !redisPassword.isEmpty()) {
+            config.useSingleServer()
+                    .setAddress(address)
+                    .setPassword(redisPassword)
+                    .setConnectionMinimumIdleSize(10)
+                    .setConnectionPoolSize(20)
+                    .setDatabase(0);
+        } else {
+            config.useSingleServer()
+                    .setAddress(address)
+                    .setConnectionMinimumIdleSize(10)
+                    .setConnectionPoolSize(20)
+                    .setDatabase(0);
+        }
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallSectionDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/request/CreateHallSectionDto.java
@@ -15,10 +15,5 @@ public record CreateHallSectionDto(
         @Schema(description = "구역의 좌석수", example = "300")
         @NotNull(message = "좌석 수량을 입력해주세요.")
         @Min(value = 0, message = "좌석 수량은 0 이상이어야 합니다.")
-        Integer seats,
-
-        @Schema(description = "좌석당 가격", example = "156000")
-        @NotNull(message = "좌석 가격을 입력해주세요.")
-        @Min(value = 0, message = "좌석 가격은 0원 이상이어야 합니다.")
-        Integer seatPrice) {
+        Integer seats) {
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/ReadHallSectionResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/dto/response/ReadHallSectionResponseDto.java
@@ -13,9 +13,6 @@ public record ReadHallSectionResponseDto(
         String sectionName,
 
         @Schema(description = "구역의 좌석수", example = "300")
-        Integer seats,
-
-        @Schema(description = "좌석당 가격", example = "156000")
-        Integer seatPrice
+        Integer seats
 ) {
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/entity/HallSection.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/entity/HallSection.java
@@ -27,20 +27,15 @@ public class HallSection extends BaseEntity {
     @Column(nullable = false)
     private Integer seats;
 
-    @Column(nullable = false)
-    private Integer seatPrice;
-
     @Builder
-    public HallSection(Hall hall, String sectionName, Integer seats, Integer seatPrice) {
+    public HallSection(Hall hall, String sectionName, Integer seats) {
         this.hall = hall;
         this.sectionName = sectionName;
         this.seats = seats;
-        this.seatPrice = seatPrice;
     }
 
-    public void update(String sectionName, Integer seats, Integer seatPrice) {
+    public void update(String sectionName, Integer seats) {
         this.sectionName = sectionName;
         this.seats = seats;
-        this.seatPrice = seatPrice;
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/service/HallSectionService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/service/HallSectionService.java
@@ -41,7 +41,7 @@ public class HallSectionService {
         }
 
         // 구역 정보 수정
-        hallSection.update(requestDto.sectionName(), requestDto.seats(), requestDto.seatPrice());
+        hallSection.update(requestDto.sectionName(), requestDto.seats());
 
         return new UpdateHallSectionResponseDto(hallSectionId);
     }
@@ -58,7 +58,7 @@ public class HallSectionService {
         }
 
         return new ReadHallSectionResponseDto(hallId, hallSectionId,
-                hallSection.getSectionName(), hallSection.getSeats(), hallSection.getSeatPrice());
+                hallSection.getSectionName(), hallSection.getSeats());
     }
 
     /* 공연장 구역 전체 조회 */
@@ -76,8 +76,7 @@ public class HallSectionService {
                         section.getHall().getHallId(),
                         section.getHallSectionId(),
                         section.getSectionName(),
-                        section.getSeats(),
-                        section.getSeatPrice()
+                        section.getSeats()
                 ))
                 .toList();
     }

--- a/src/main/java/com/dayaeyak/performance/domain/hall/service/HallService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/hall/service/HallService.java
@@ -153,7 +153,6 @@ public class HallService {
                         .hall(hall)
                         .sectionName(sectionDto.sectionName())
                         .seats(sectionDto.seats())
-                        .seatPrice(sectionDto.seatPrice())
                         .build())
                 .toList();
     }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceController.java
@@ -1,5 +1,6 @@
 package com.dayaeyak.performance.domain.performance.controller;
 
+import com.dayaeyak.performance.domain.hall.enums.Region;
 import com.dayaeyak.performance.domain.performance.dto.request.ChangePerformanceRequestDto;
 import com.dayaeyak.performance.domain.performance.dto.request.CreatePerformanceRequestDto;
 import com.dayaeyak.performance.domain.performance.dto.request.UpdatePerformanceRequestDto;
@@ -66,10 +67,11 @@ public class PerformanceController {
     public ResponseEntity<ApiResponse<ReadPerformancePageResponseDto>> readPerformanceList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) Type type) {
+            @RequestParam(required = false) Type type,
+            @RequestParam(required = false) Region region) {
         return ApiResponse.success(HttpStatus.OK.value(),
                 "공연 목록을 조회합니다.",
-                performanceService.readPerformanceList(page, size, type));
+                performanceService.readPerformanceList(page, size, type, region));
     }
 
     @Operation(summary = "Delete Performance", description = "공연을 삭제합니다.")

--- a/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSectionController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSectionController.java
@@ -1,0 +1,45 @@
+package com.dayaeyak.performance.domain.performance.controller;
+
+import com.dayaeyak.performance.domain.performance.dto.response.ReadPerformanceSectionResponseDto;
+import com.dayaeyak.performance.domain.performance.service.PerformanceSectionService;
+import com.dayaeyak.performance.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/performances/{performanceId}/sessions/{sessionId}/sections")
+@RequiredArgsConstructor
+@Tag(name = "Performance Section API")
+public class PerformanceSectionController {
+    private final PerformanceSectionService performanceSectionService;
+
+    @Operation(summary = "Read Performance Section", description = "단건 회차 구역 정보를 조회합니다.")
+    @GetMapping("/{sectionId}")
+    public ResponseEntity<ApiResponse<ReadPerformanceSectionResponseDto>> readPerformanceSection(
+            @PathVariable Long performanceId,
+            @PathVariable Long sessionId,
+            @PathVariable Long sectionId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "해당 회차 구역 정보를 조회합니다.",
+                performanceSectionService.readPerformanceSection(performanceId, sessionId, sectionId));
+    }
+
+    @Operation(summary = "Read All Performance Sections", description = "공연 회차의 전체 구역을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ReadPerformanceSectionResponseDto>>> readPerformanceSections(
+            @PathVariable Long performanceId,
+            @PathVariable Long sessionId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "해당 공연 회차의 전체 구역 정보를 조회합니다.",
+                performanceSectionService.readPerformanceSections(performanceId, sessionId));
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSessionController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSessionController.java
@@ -63,4 +63,14 @@ public class PerformanceSessionController {
                 performanceSessionService.readSessionList(performanceId));
     }
 
+    @Operation(summary = "Delete Performance Session", description = "공연 회차를 삭제합니다.")
+    @DeleteMapping("/{sessionId}")
+    public ResponseEntity<ApiResponse<Void>> deleteSession(
+            @PathVariable Long performanceId,
+            @PathVariable Long sessionId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "해당 공연 회차를 삭제합니다.",
+                performanceSessionService.deleteSession(performanceId, sessionId));
+    }
+
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSessionController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSessionController.java
@@ -3,6 +3,7 @@ package com.dayaeyak.performance.domain.performance.controller;
 import com.dayaeyak.performance.domain.performance.dto.request.CreateSessionRequestDto;
 import com.dayaeyak.performance.domain.performance.dto.request.UpdateSessionRequestDto;
 import com.dayaeyak.performance.domain.performance.dto.response.CreateSessionResponseDto;
+import com.dayaeyak.performance.domain.performance.dto.response.ReadSessionResponseDto;
 import com.dayaeyak.performance.domain.performance.service.PerformanceSessionService;
 import com.dayaeyak.performance.utils.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/performances/{performanceId}/sessions")
@@ -40,4 +43,24 @@ public class PerformanceSessionController {
                 "공연 회차 정보를 수정했습니다.",
                 performanceSessionService.updateSession(performanceId, sessionId, requestDto));
     }
+
+    @Operation(summary = "Read Performance Session", description = "단건 공연 회차 정보를 조회합니다.")
+    @GetMapping("/{sessionId}")
+    public ResponseEntity<ApiResponse<ReadSessionResponseDto>> readSession(
+            @PathVariable Long performanceId,
+            @PathVariable Long sessionId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "단건 공연 회차 정보를 조회합니다.",
+                performanceSessionService.readSession(performanceId, sessionId));
+    }
+
+    @Operation(summary = "Read All Performance Sessions", description = "공연의 전체 회차를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ReadSessionResponseDto>>> readSessionList(
+            @PathVariable Long performanceId){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "해당 공연의 전체 회차 정보를 조회합니다.",
+                performanceSessionService.readSessionList(performanceId));
+    }
+
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSessionController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSessionController.java
@@ -1,0 +1,31 @@
+package com.dayaeyak.performance.domain.performance.controller;
+
+import com.dayaeyak.performance.domain.performance.dto.request.CreateSessionRequestDto;
+import com.dayaeyak.performance.domain.performance.dto.response.CreateSessionResponseDto;
+import com.dayaeyak.performance.domain.performance.service.PerformanceSessionService;
+import com.dayaeyak.performance.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/performances/{performanceId}/sessions")
+@RequiredArgsConstructor
+@Tag(name = "Performance Session API")
+public class PerformanceSessionController {
+    private final PerformanceSessionService performanceSessionService;
+
+    @Operation(summary = "Create Performance Session", description = "공연 회차를 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateSessionResponseDto>> createSession(
+            @PathVariable Long performanceId,
+            @Validated @RequestBody CreateSessionRequestDto requestDto) {
+        return ApiResponse.success(HttpStatus.CREATED.value(),
+                "공연 회차가 생성되었습니다.",
+                performanceSessionService.createSession(performanceId, requestDto));
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSessionController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/controller/PerformanceSessionController.java
@@ -1,6 +1,7 @@
 package com.dayaeyak.performance.domain.performance.controller;
 
 import com.dayaeyak.performance.domain.performance.dto.request.CreateSessionRequestDto;
+import com.dayaeyak.performance.domain.performance.dto.request.UpdateSessionRequestDto;
 import com.dayaeyak.performance.domain.performance.dto.response.CreateSessionResponseDto;
 import com.dayaeyak.performance.domain.performance.service.PerformanceSessionService;
 import com.dayaeyak.performance.utils.ApiResponse;
@@ -27,5 +28,16 @@ public class PerformanceSessionController {
         return ApiResponse.success(HttpStatus.CREATED.value(),
                 "공연 회차가 생성되었습니다.",
                 performanceSessionService.createSession(performanceId, requestDto));
+    }
+
+    @Operation(summary = "Update Performance Session", description = "공연 회차 정보를 수정합니다.")
+    @PatchMapping("/{sessionId}")
+    public ResponseEntity<ApiResponse<CreateSessionResponseDto>> updateSession(
+            @PathVariable Long performanceId,
+            @PathVariable Long sessionId,
+            @Validated @RequestBody UpdateSessionRequestDto requestDto){
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "공연 회차 정보를 수정했습니다.",
+                performanceSessionService.updateSession(performanceId, sessionId, requestDto));
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/controller/SeatController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/controller/SeatController.java
@@ -1,0 +1,34 @@
+
+package com.dayaeyak.performance.domain.performance.controller;
+
+import com.dayaeyak.performance.domain.performance.dto.request.UpdateSeatSoldOutRequestDto;
+import com.dayaeyak.performance.domain.performance.dto.response.SeatResponseDto;
+import com.dayaeyak.performance.domain.performance.service.SeatService;
+import com.dayaeyak.performance.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/performances/{performanceId}/sessions/{sessionId}/sections/{sectionId}/seats")
+@RequiredArgsConstructor
+@Tag(name = "Performance Seat API")
+public class SeatController {
+    private final SeatService seatService;
+
+    @Operation(summary = "Change IsSoldOut", description = "좌석의 품절 여부를 변경합니다.")
+    @PatchMapping("/{seatId}")
+    public ResponseEntity<ApiResponse<SeatResponseDto>> changeIsSoldOut(
+            @PathVariable Long performanceId,
+            @PathVariable Long sessionId,
+            @PathVariable Long sectionId,
+            @PathVariable Long seatId,
+            @RequestBody UpdateSeatSoldOutRequestDto requestDto) {
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "해당 좌석의 품절 여부를 변경했습니다.",
+                seatService.changeIsSoldOut(performanceId, sessionId, sectionId, seatId, requestDto));
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/controller/SeatController.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/controller/SeatController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/performances/{performanceId}/sessions/{sessionId}/sections/{sectionId}/seats")
 @RequiredArgsConstructor
@@ -31,4 +33,29 @@ public class SeatController {
                 "해당 좌석의 품절 여부를 변경했습니다.",
                 seatService.changeIsSoldOut(performanceId, sessionId, sectionId, seatId, requestDto));
     }
+
+    @Operation(summary = "Read Performance Seat", description = "해당 좌석의 상세 정보를 조회합니다.")
+    @GetMapping("/{seatId}")
+    public ResponseEntity<ApiResponse<SeatResponseDto>> readPerformanceSeat(
+            @PathVariable Long performanceId,
+            @PathVariable Long sessionId,
+            @PathVariable Long sectionId,
+            @PathVariable Long seatId) {
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "좌석 정보를 조회합니다.",
+                seatService.readPerformanceSeat(performanceId, sessionId, sectionId, seatId));
+    }
+
+    @Operation(summary = "Get IsSoldOut of all Seats", description = "전체 좌석의 품절 여부를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<Boolean>>> readPerformanceSeats(
+            @PathVariable Long performanceId,
+            @PathVariable Long sessionId,
+            @PathVariable Long sectionId) {
+        return ApiResponse.success(HttpStatus.OK.value(),
+                "해당 구역 전체 좌석의 품절 여부를 좌석 번호 순서대로 조회합니다.",
+                seatService.readPerformanceSeats(performanceId, sessionId, sectionId));
+    }
+
+
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/CreateSessionRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/CreateSessionRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Map;
 
 public record CreateSessionRequestDto(
         @Schema(description = "공연 ID", example = "3")
@@ -17,6 +18,10 @@ public record CreateSessionRequestDto(
 
         @Schema(description = "공연 회차 시간", example = "18:00:00")
         @NotNull(message = "공연 회차 시간은 필수 입력값입니다.")
-        LocalTime time
+        LocalTime time,
+
+        @Schema(description = "구역별 좌석 가격")
+        @NotNull(message = "구역별 좌석 가격은 필수 입력값입니다.")
+        Map<String, Integer> sectionPrices
 ) {
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/CreateSessionRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/CreateSessionRequestDto.java
@@ -1,0 +1,22 @@
+package com.dayaeyak.performance.domain.performance.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CreateSessionRequestDto(
+        @Schema(description = "공연 ID", example = "3")
+        @NotNull(message = "공연 ID는 필수 입력값입니다.")
+        Long performanceId,
+
+        @Schema(description = "공연 회차 날짜", example = "2025-10-05")
+        @NotNull(message = "공연 회차 날짜는 필수 입력값입니다.")
+        LocalDate date,
+
+        @Schema(description = "공연 회차 시간", example = "18:00:00")
+        @NotNull(message = "공연 회차 시간은 필수 입력값입니다.")
+        LocalTime time
+) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/UpdateSeatSoldOutRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/UpdateSeatSoldOutRequestDto.java
@@ -1,0 +1,9 @@
+package com.dayaeyak.performance.domain.performance.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateSeatSoldOutRequestDto(
+        @Schema(description = "좌석 품절 여부", example = "true")
+        boolean isSoldOut
+) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/UpdateSessionRequestDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/request/UpdateSessionRequestDto.java
@@ -1,0 +1,18 @@
+package com.dayaeyak.performance.domain.performance.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record UpdateSessionRequestDto(
+        @Schema(description = "공연 회차 날짜", example = "2025-10-05")
+        @NotNull(message = "공연 회차 날짜는 필수 입력값입니다.")
+        LocalDate date,
+
+        @Schema(description = "공연 회차 시간", example = "18:00:00")
+        @NotNull(message = "공연 회차 시간은 필수 입력값입니다.")
+        LocalTime time
+) {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/CreateSessionResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/CreateSessionResponseDto.java
@@ -1,0 +1,8 @@
+package com.dayaeyak.performance.domain.performance.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateSessionResponseDto(
+        @Schema(description = "공연 회차 ID", example = "1")
+        Long performanceSessionId
+) { }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/ReadPerformanceResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/ReadPerformanceResponseDto.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.sql.Timestamp;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 @Builder
@@ -37,10 +37,10 @@ public record ReadPerformanceResponseDto(
         Grade grade,
 
         @Schema(description = "공연 시작일", example = "2025-10-01")
-        Date startDate,
+        LocalDate startDate,
 
         @Schema(description = "공연 종료일", example = "2025-10-31")
-        Date endDate,
+        LocalDate endDate,
 
         @Schema(description = "티켓 오픈 일시", example = "2025-09-01T09:00:00")
         Timestamp ticketOpenAt,

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/ReadPerformanceSectionResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/ReadPerformanceSectionResponseDto.java
@@ -1,0 +1,34 @@
+package com.dayaeyak.performance.domain.performance.dto.response;
+
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ReadPerformanceSectionResponseDto(
+        @Schema(description = "공연 ID", example = "1")
+        Long performanceId,
+
+        @Schema(description = "공연 회차 ID", example = "3")
+        Long sessionId,
+
+        @Schema(description = "회차 구역 ID", example = "6")
+        Long sectionId,
+
+        @Schema(description = "구역명", example = "101")
+        String sectionName,
+
+        @Schema(description = "남은 좌석 수", example = "210")
+        Integer remainingSeats
+) {
+
+    public static ReadPerformanceSectionResponseDto from(PerformanceSection performanceSection) {
+        return ReadPerformanceSectionResponseDto.builder()
+                .performanceId(performanceSection.getPerformanceSession().getPerformance().getPerformanceId())
+                .sessionId(performanceSection.getPerformanceSession().getPerformanceSessionId())
+                .sectionId(performanceSection.getPerformanceSectionId())
+                .sectionName(performanceSection.getSectionName())
+                .remainingSeats(performanceSection.getRemainingSeats())
+                .build();
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/ReadSessionResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/ReadSessionResponseDto.java
@@ -1,0 +1,33 @@
+package com.dayaeyak.performance.domain.performance.dto.response;
+
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Builder
+public record ReadSessionResponseDto(
+        @Schema(description = "공연 ID", example = "1")
+        Long performanceId,
+
+        @Schema(description = "공연 회차 ID", example = "3")
+        Long sessionId,
+
+        @Schema(description = "공연 회차 날짜", example = "2025-11-01")
+        LocalDate date,
+
+        @Schema(description = "공연 회차 시간", example = "14:00:00")
+        LocalTime time
+) {
+
+    public static ReadSessionResponseDto from(PerformanceSession performanceSession) {
+        return ReadSessionResponseDto.builder()
+                .performanceId(performanceSession.getPerformance().getPerformanceId())
+                .sessionId(performanceSession.getPerformanceSessionId())
+                .date(performanceSession.getDate())
+                .time(performanceSession.getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/SeatResponseDto.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/dto/response/SeatResponseDto.java
@@ -1,0 +1,38 @@
+package com.dayaeyak.performance.domain.performance.dto.response;
+
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSeat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record SeatResponseDto(
+        @Schema(description = "공연 ID", example = "1")
+        Long performanceId,
+
+        @Schema(description = "공연 회차 ID", example = "3")
+        Long sessionId,
+
+        @Schema(description = "회차 구역 ID", example = "6")
+        Long sectionId,
+
+        @Schema(description = "구역 좌석 ID", example = "4521")
+        Long seatId,
+
+        @Schema(description = "좌석 번호", example = "32")
+        Integer seatNumber,
+
+        @Schema(description = "좌석 품절 여부", example = "true")
+        Boolean isSoldOut)
+{
+    public static SeatResponseDto from(PerformanceSeat seat){
+        return SeatResponseDto.builder()
+                .performanceId(seat.getPerformanceSection().getPerformanceSession().getPerformance().getPerformanceId())
+                .sessionId(seat.getPerformanceSection().getPerformanceSession().getPerformanceSessionId())
+                .sectionId(seat.getPerformanceSection().getPerformanceSectionId())
+                .seatId(seat.getPerformanceSeatId())
+                .seatNumber(seat.getSeatNumber())
+                .isSoldOut(seat.getIsSoldOut())
+                .build();
+
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/entity/Performance.java
@@ -6,12 +6,15 @@ import com.dayaeyak.performance.domain.hall.entity.Hall;
 import com.dayaeyak.performance.domain.performance.enums.Grade;
 import com.dayaeyak.performance.domain.performance.enums.Type;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 @Entity
@@ -45,11 +48,11 @@ public class Performance extends BaseEntity {
 
     @Column(nullable = false)
     @Temporal(TemporalType.DATE)
-    private Date startDate;
+    private LocalDate startDate;
 
     @Column(nullable = false)
     @Temporal(TemporalType.DATE)
-    private Date endDate;
+    private LocalDate endDate;
 
     @Column(nullable = false)
     private Timestamp ticketOpenAt;
@@ -81,7 +84,7 @@ public class Performance extends BaseEntity {
 
     @Builder
     public Performance(Long sellerId, Hall hall, String performanceName, String description, Type type, Grade grade,
-                       Date startDate, Date endDate, Timestamp ticketOpenAt, Timestamp ticketCloseAt, Boolean isActivated) {
+                       LocalDate startDate, LocalDate endDate, Timestamp ticketOpenAt, Timestamp ticketCloseAt, Boolean isActivated) {
         this.sellerId = sellerId;
         this.hall = hall;
         this.performanceName = performanceName;
@@ -115,11 +118,11 @@ public class Performance extends BaseEntity {
         this.grade = grade;
     }
 
-    public void updateStartDate(Date startDate) {
+    public void updateStartDate(LocalDate startDate) {
         this.startDate = startDate;
     }
 
-    public void updateEndDate(Date endDate) {
+    public void updateEndDate(LocalDate endDate) {
         this.endDate = endDate;
     }
 

--- a/src/main/java/com/dayaeyak/performance/domain/performance/entity/PerformanceSeat.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/entity/PerformanceSeat.java
@@ -1,0 +1,44 @@
+package com.dayaeyak.performance.domain.performance.entity;
+
+import com.dayaeyak.performance.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "performance_seats")
+public class PerformanceSeat extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long performanceSeatId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_section_id", nullable = false)
+    private PerformanceSection performanceSection;
+
+    @Column(nullable = false)
+    private Integer seatNumber;
+
+    @Column(nullable = false)
+    private Boolean isSoldOut;
+
+    public PerformanceSeat(PerformanceSection performanceSection, Integer seatNumber) {
+        this.performanceSection = performanceSection;
+        this.seatNumber = seatNumber;
+        this.isSoldOut = false;
+    }
+
+    public void sellOut() {
+        this.isSoldOut = true;
+    }
+
+    public void reopen(){
+        this.isSoldOut = false;
+    }
+
+
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/entity/PerformanceSection.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/entity/PerformanceSection.java
@@ -1,0 +1,56 @@
+package com.dayaeyak.performance.domain.performance.entity;
+
+import com.dayaeyak.performance.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "performance_sections")
+public class PerformanceSection extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long performanceSectionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_session_id", nullable = false)
+    private PerformanceSession performanceSession;
+
+    @Column(length = 50, nullable = false)
+    private String sectionName;
+
+    @Column(nullable = false)
+    private Integer seatPrice;
+
+    @Column(nullable = false)
+    private Integer remainingSeats;
+
+    @Builder
+    public PerformanceSection(PerformanceSession performanceSession, String sectionName, Integer seatPrice, Integer remainingSeats) {
+        this.performanceSession = performanceSession;
+        this.sectionName = sectionName;
+        this.seatPrice = seatPrice;
+        this.remainingSeats = remainingSeats;
+    }
+
+    public void update(String sectionName, Integer seatPrice) {
+        this.sectionName = sectionName;
+        this.seatPrice = seatPrice;
+    }
+
+    public void decreaseRemainingSeats() {
+        if(this.remainingSeats <= 0) {
+            throw new IllegalStateException("남은 좌석 수는 0보다 작을 수 없습니다.");
+        }
+        this.remainingSeats--;
+    }
+
+    public void increaseRemainingSeats() {
+        this.remainingSeats++;
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/entity/PerformanceSession.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/entity/PerformanceSession.java
@@ -6,8 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Date;
-import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -24,18 +24,18 @@ public class PerformanceSession extends BaseEntity {
     private Performance performance;
 
     @Column(nullable = false)
-    private Date date;
+    private LocalDate date;
 
     @Column(nullable = false)
-    private Time time;
+    private LocalTime time;
 
-    public PerformanceSession(Performance performance, Date date, Time time) {
+    public PerformanceSession(Performance performance, LocalDate date, LocalTime time) {
         this.performance = performance;
         this.date = date;
         this.time = time;
     }
 
-    public void update(Date date, Time time) {
+    public void update(LocalDate date, LocalTime time) {
         this.date = date;
         this.time = time;
     }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/entity/PerformanceSession.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/entity/PerformanceSession.java
@@ -1,0 +1,42 @@
+package com.dayaeyak.performance.domain.performance.entity;
+
+import com.dayaeyak.performance.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Date;
+import java.sql.Time;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "performance_sessions")
+public class PerformanceSession extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long performanceSessionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id", nullable = false)
+    private Performance performance;
+
+    @Column(nullable = false)
+    private Date date;
+
+    @Column(nullable = false)
+    private Time time;
+
+    public PerformanceSession(Performance performance, Date date, Time time) {
+        this.performance = performance;
+        this.date = date;
+        this.time = time;
+    }
+
+    public void update(Date date, Time time) {
+        this.date = date;
+        this.time = time;
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
@@ -17,7 +17,10 @@ public enum PerformanceErrorCode implements ErrorCode {
     MISMATCHED_PERFORMANCE_ID(HttpStatus.BAD_REQUEST, "공연 ID가 일치하지 않습니다."),
     MISMATCHED_PERFORMANCE_AND_SESSION(HttpStatus.BAD_REQUEST, "선택한 회차가 해당 공연에 속하지 않습니다."),
     INVALID_SESSION_DATE(HttpStatus.BAD_REQUEST, "공연 회차 날짜는 공연 시작일과 마감일 사이여야 합니다."),
-    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "공연 회차 정보를 찾을 수 없습니다.");
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "공연 회차 정보를 찾을 수 없습니다."),
+    INVALID_SECTION_NAMES(HttpStatus.BAD_REQUEST, "공연장에 없는 구역이 요청 본문에 포함되어 있습니다."),
+    MISSING_SECTION_PRICES(HttpStatus.BAD_REQUEST, "가격 정보가 누락된 구역이 있습니다."),
+    INVALID_SEAT_PRICE(HttpStatus.BAD_REQUEST, "좌석 가격은 0보다 커야 합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
@@ -20,7 +20,10 @@ public enum PerformanceErrorCode implements ErrorCode {
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "공연 회차 정보를 찾을 수 없습니다."),
     INVALID_SECTION_NAMES(HttpStatus.BAD_REQUEST, "공연장에 없는 구역이 요청 본문에 포함되어 있습니다."),
     MISSING_SECTION_PRICES(HttpStatus.BAD_REQUEST, "가격 정보가 누락된 구역이 있습니다."),
-    INVALID_SEAT_PRICE(HttpStatus.BAD_REQUEST, "좌석 가격은 0보다 커야 합니다.");
+    INVALID_SEAT_PRICE(HttpStatus.BAD_REQUEST, "좌석 가격은 0보다 커야 합니다."),
+
+    SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "공연 회차 구역 정보를 찾을 수 없습니다."),
+    MISMATCHED_SESSION_AND_SECTION(HttpStatus.BAD_REQUEST, "선택한 공연 회차 구역이 해당 공연 회차에 속하지 않습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
@@ -12,7 +12,11 @@ public enum PerformanceErrorCode implements ErrorCode {
     CANNOT_CHANGE_ACTIVATION(HttpStatus.BAD_REQUEST, "지금은 공연의 활성화 상태를 변경할 수 없습니다."),
     PERFORMANCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "공연 정보를 찾을 수 없습니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "공연 시작일과 종료일의 범위가 올바르지 않습니다."),
-    INVALID_TICKET_TIME_RANGE(HttpStatus.BAD_REQUEST, "티켓오픈일시와 마감일시의 범위가 올바르지 않습니다.");
+    INVALID_TICKET_TIME_RANGE(HttpStatus.BAD_REQUEST, "티켓오픈일시와 마감일시의 범위가 올바르지 않습니다."),
+
+    MISMATCHED_PERFORMANCE_ID(HttpStatus.BAD_REQUEST, "공연 ID가 일치하지 않습니다."),
+    INVALID_SESSION_DATE(HttpStatus.BAD_REQUEST, "공연 회차 날짜는 공연 시작일과 마감일 사이여야 합니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
@@ -23,7 +23,17 @@ public enum PerformanceErrorCode implements ErrorCode {
     INVALID_SEAT_PRICE(HttpStatus.BAD_REQUEST, "좌석 가격은 0보다 커야 합니다."),
 
     SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "공연 회차 구역 정보를 찾을 수 없습니다."),
-    MISMATCHED_SESSION_AND_SECTION(HttpStatus.BAD_REQUEST, "선택한 공연 회차 구역이 해당 공연 회차에 속하지 않습니다.");
+    MISMATCHED_SESSION_AND_SECTION(HttpStatus.BAD_REQUEST, "선택한 공연 회차 구역이 해당 공연 회차에 속하지 않습니다."),
+    SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 정보를 확인할 수 없습니다."),
+    MISMATCHED_SECTION_AND_SEAT(HttpStatus.BAD_REQUEST, "선택한 좌석이 해당 공연 회차 구역에 속하지 않습니다."),
+
+    SEAT_ALREADY_SOLD_OUT(HttpStatus.CONFLICT, "해당 좌석은 이미 품절되었습니다."),
+    SEAT_ALREADY_OPEN(HttpStatus.CONFLICT, "해당 좌석은 이미 품절되지 않은 상태입니다."),
+
+    // 분산락
+    LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "현재 다른 요청 처리 중입니다. 잠시 후 다시 시도해주세요."),
+    LOCK_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "처리 중 오류가 발생했습니다. 다시 시도해주세요."),
+    CONCURRENT_SEAT_MODIFICATION(HttpStatus.CONFLICT, "다른 요청과 충돌했습니다. 잠시 후 다시 시도해주세요.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/exception/PerformanceErrorCode.java
@@ -15,7 +15,9 @@ public enum PerformanceErrorCode implements ErrorCode {
     INVALID_TICKET_TIME_RANGE(HttpStatus.BAD_REQUEST, "티켓오픈일시와 마감일시의 범위가 올바르지 않습니다."),
 
     MISMATCHED_PERFORMANCE_ID(HttpStatus.BAD_REQUEST, "공연 ID가 일치하지 않습니다."),
-    INVALID_SESSION_DATE(HttpStatus.BAD_REQUEST, "공연 회차 날짜는 공연 시작일과 마감일 사이여야 합니다.");
+    MISMATCHED_PERFORMANCE_AND_SESSION(HttpStatus.BAD_REQUEST, "선택한 회차가 해당 공연에 속하지 않습니다."),
+    INVALID_SESSION_DATE(HttpStatus.BAD_REQUEST, "공연 회차 날짜는 공연 시작일과 마감일 사이여야 합니다."),
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "공연 회차 정보를 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceRepository.java
@@ -1,6 +1,7 @@
 package com.dayaeyak.performance.domain.performance.repository;
 
 import com.dayaeyak.performance.domain.hall.entity.Hall;
+import com.dayaeyak.performance.domain.hall.enums.Region;
 import com.dayaeyak.performance.domain.performance.entity.Performance;
 import com.dayaeyak.performance.domain.performance.enums.Type;
 import org.springframework.data.domain.Page;
@@ -17,4 +18,7 @@ public interface PerformanceRepository extends JpaRepository<Performance,Long> {
     Page<Performance> findByDeletedAtIsNullAndTypeAndIsActivatedIsTrue(Pageable pageable, Type type);
     boolean existsByHallAndDeletedAtIsNull(Hall hall);
     Boolean existsByHallAndEndDateGreaterThanEqualAndDeletedAtIsNull(Hall hall, LocalDate now);
+    Page<Performance> findByDeletedAtIsNullAndIsActivatedIsTrueAndHall_Region(Pageable pageable, Region region);
+    Page<Performance> findByDeletedAtIsNullAndTypeAndIsActivatedIsTrueAndHall_Region(Pageable pageable, Type type, Region region);
+
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSeatRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSeatRepository.java
@@ -3,6 +3,8 @@ package com.dayaeyak.performance.domain.performance.repository;
 import com.dayaeyak.performance.domain.performance.entity.PerformanceSeat;
 import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,10 @@ import java.util.Optional;
 public interface PerformanceSeatRepository extends JpaRepository<PerformanceSeat, Long> {
     List<PerformanceSeat> findByPerformanceSectionAndDeletedAtIsNull(PerformanceSection performanceSection);
     Optional<PerformanceSeat> findByPerformanceSeatIdAndDeletedAtIsNull(Long performanceSeatId);
+
+    @Query(value = "SELECT is_sold_out FROM performance_seats " +
+            "WHERE performance_section_id = :sectionId " +
+            "ORDER BY seat_number ASC", nativeQuery = true)
+    List<Boolean> findIsSoldOutBySectionIdNative(@Param("sectionId") Long sectionId);
+
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSeatRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSeatRepository.java
@@ -1,0 +1,7 @@
+package com.dayaeyak.performance.domain.performance.repository;
+
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSeat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceSeatRepository extends JpaRepository<PerformanceSeat, Long> {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSeatRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSeatRepository.java
@@ -1,7 +1,11 @@
 package com.dayaeyak.performance.domain.performance.repository;
 
 import com.dayaeyak.performance.domain.performance.entity.PerformanceSeat;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PerformanceSeatRepository extends JpaRepository<PerformanceSeat, Long> {
+    List<PerformanceSeat> findByPerformanceSectionAndDeletedAtIsNull(PerformanceSection performanceSection);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSeatRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSeatRepository.java
@@ -5,7 +5,9 @@ import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PerformanceSeatRepository extends JpaRepository<PerformanceSeat, Long> {
     List<PerformanceSeat> findByPerformanceSectionAndDeletedAtIsNull(PerformanceSection performanceSection);
+    Optional<PerformanceSeat> findByPerformanceSeatIdAndDeletedAtIsNull(Long performanceSeatId);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSectionRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSectionRepository.java
@@ -1,7 +1,11 @@
 package com.dayaeyak.performance.domain.performance.repository;
 
 import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PerformanceSectionRepository extends JpaRepository<PerformanceSection, Long> {
+    List<PerformanceSection> findByPerformanceSessionAndDeletedAtIsNull(PerformanceSession session);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSectionRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSectionRepository.java
@@ -5,7 +5,9 @@ import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PerformanceSectionRepository extends JpaRepository<PerformanceSection, Long> {
     List<PerformanceSection> findByPerformanceSessionAndDeletedAtIsNull(PerformanceSession session);
+    Optional<PerformanceSection> findByPerformanceSectionIdAndDeletedAtIsNull(Long performanceSectionId);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSectionRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSectionRepository.java
@@ -1,0 +1,7 @@
+package com.dayaeyak.performance.domain.performance.repository;
+
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceSectionRepository extends JpaRepository<PerformanceSection, Long> {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSessionRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSessionRepository.java
@@ -1,10 +1,13 @@
 package com.dayaeyak.performance.domain.performance.repository;
 
+import com.dayaeyak.performance.domain.performance.entity.Performance;
 import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PerformanceSessionRepository extends JpaRepository<PerformanceSession, Long> {
     Optional<PerformanceSession> findByPerformanceSessionIdAndDeletedAtIsNull(Long sessionId);
+    List<PerformanceSession> findByPerformanceAndDeletedAtIsNull(Performance performance);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSessionRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSessionRepository.java
@@ -1,0 +1,7 @@
+package com.dayaeyak.performance.domain.performance.repository;
+
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceSessionRepository extends JpaRepository<PerformanceSession, Long> {
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSessionRepository.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/repository/PerformanceSessionRepository.java
@@ -3,5 +3,8 @@ package com.dayaeyak.performance.domain.performance.repository;
 import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PerformanceSessionRepository extends JpaRepository<PerformanceSession, Long> {
+    Optional<PerformanceSession> findByPerformanceSessionIdAndDeletedAtIsNull(Long sessionId);
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceSectionService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceSectionService.java
@@ -1,0 +1,62 @@
+package com.dayaeyak.performance.domain.performance.service;
+
+import com.dayaeyak.performance.common.exception.CustomException;
+import com.dayaeyak.performance.domain.performance.dto.response.ReadPerformanceSectionResponseDto;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
+import com.dayaeyak.performance.domain.performance.exception.PerformanceErrorCode;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSeatRepository;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSectionRepository;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PerformanceSectionService {
+    private final PerformanceSectionRepository performanceSectionRepository;
+    private final PerformanceSessionRepository performanceSessionRepository;
+    private final PerformanceSeatRepository performanceSeatRepository;
+
+    /* 공연 회차 구역 조회 */
+    public ReadPerformanceSectionResponseDto readPerformanceSection(Long performanceId, Long sessionId, Long sectionId){
+        PerformanceSection section = performanceSectionRepository.findByPerformanceSectionIdAndDeletedAtIsNull(sectionId)
+                .orElseThrow(() -> new CustomException(PerformanceErrorCode.SECTION_NOT_FOUND));
+
+        // 회차 구역이 요청한 공연 회차에 속하는지 검증
+        if (!Objects.equals(section.getPerformanceSession().getPerformanceSessionId(), sessionId)) {
+            throw new CustomException(PerformanceErrorCode.MISMATCHED_SESSION_AND_SECTION);
+        }
+
+        // 공연 회차가 요청한 공연에 속하는지 검증
+        if (!Objects.equals(section.getPerformanceSession().getPerformance().getPerformanceId(), performanceId)) {
+            throw new CustomException(PerformanceErrorCode.MISMATCHED_PERFORMANCE_AND_SESSION);
+        }
+
+        return ReadPerformanceSectionResponseDto.from(section);
+    }
+
+    /* 공연 회차 구역 전체 조회 */
+    public List<ReadPerformanceSectionResponseDto> readPerformanceSections(Long performanceId, Long sessionId){
+        // 공연 회차 조회
+        PerformanceSession session = performanceSessionRepository.findByPerformanceSessionIdAndDeletedAtIsNull(sessionId)
+                .orElseThrow(() -> new CustomException(PerformanceErrorCode.SESSION_NOT_FOUND));
+
+        // 공연 회차가 해당 공연에 속하는지 검증
+        if (!Objects.equals(session.getPerformance().getPerformanceId(), performanceId)) {
+            throw new CustomException(PerformanceErrorCode.MISMATCHED_PERFORMANCE_AND_SESSION);
+        }
+
+        // 해당 공연 회차의 구역 전체 조회
+        List<PerformanceSection> sections = performanceSectionRepository.findByPerformanceSessionAndDeletedAtIsNull(session);
+
+        return sections.stream().
+                map(ReadPerformanceSectionResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceSectionService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceSectionService.java
@@ -5,7 +5,6 @@ import com.dayaeyak.performance.domain.performance.dto.response.ReadPerformanceS
 import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
 import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
 import com.dayaeyak.performance.domain.performance.exception.PerformanceErrorCode;
-import com.dayaeyak.performance.domain.performance.repository.PerformanceSeatRepository;
 import com.dayaeyak.performance.domain.performance.repository.PerformanceSectionRepository;
 import com.dayaeyak.performance.domain.performance.repository.PerformanceSessionRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +20,6 @@ import java.util.Objects;
 public class PerformanceSectionService {
     private final PerformanceSectionRepository performanceSectionRepository;
     private final PerformanceSessionRepository performanceSessionRepository;
-    private final PerformanceSeatRepository performanceSeatRepository;
 
     /* 공연 회차 구역 조회 */
     public ReadPerformanceSectionResponseDto readPerformanceSection(Long performanceId, Long sessionId, Long sectionId){

--- a/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceService.java
@@ -27,8 +27,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -64,8 +64,8 @@ public class PerformanceService {
                 .description(requestDto.description())
                 .type(requestDto.type())
                 .grade(requestDto.grade())
-                .startDate(java.sql.Date.valueOf(requestDto.startDate()))
-                .endDate(java.sql.Date.valueOf(requestDto.endDate()))
+                .startDate(requestDto.startDate())
+                .endDate(requestDto.endDate())
                 .ticketOpenAt(Timestamp.valueOf(requestDto.ticketOpenAt()))
                 .ticketCloseAt(Timestamp.valueOf(requestDto.ticketCloseAt()))
                 .isActivated(requestDto.isActivated() == null || requestDto.isActivated())
@@ -144,20 +144,20 @@ public class PerformanceService {
 
         // 시작일/마감일 수정
         if (requestDto.startDate() != null) {
-            Date startDate = java.sql.Date.valueOf(requestDto.startDate());
+            LocalDate startDate = requestDto.startDate();
 
             // 종료일이 이미 설정되어 있다면 시작일이 종료일보다 이후가 되지 않도록 검증
-            if (performance.getEndDate() != null && startDate.after(performance.getEndDate())) {
+            if (performance.getEndDate() != null && startDate.isAfter(performance.getEndDate())) {
                 throw new CustomException(PerformanceErrorCode.INVALID_DATE_RANGE);
             }
 
             performance.updateStartDate(startDate);
         }
         if (requestDto.endDate() != null) {
-            Date endDate = java.sql.Date.valueOf(requestDto.endDate());
+            LocalDate endDate = requestDto.endDate();
 
             // 시작일이 이미 설정되어 있다면 종료일이 시작일보다 이전이 되지 않도록 검증
-            if (performance.getStartDate() != null && endDate.before(performance.getStartDate())) {
+            if (performance.getStartDate() != null && endDate.isBefore(performance.getStartDate())) {
                 throw new CustomException(PerformanceErrorCode.INVALID_DATE_RANGE);
             }
 

--- a/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceService.java
@@ -16,9 +16,15 @@ import com.dayaeyak.performance.domain.performance.dto.response.CreatePerformanc
 import com.dayaeyak.performance.domain.performance.dto.response.ReadPerformancePageResponseDto;
 import com.dayaeyak.performance.domain.performance.dto.response.ReadPerformanceResponseDto;
 import com.dayaeyak.performance.domain.performance.entity.Performance;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSeat;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
 import com.dayaeyak.performance.domain.performance.enums.Type;
 import com.dayaeyak.performance.domain.performance.exception.PerformanceErrorCode;
 import com.dayaeyak.performance.domain.performance.repository.PerformanceRepository;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSeatRepository;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSectionRepository;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSessionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +45,9 @@ public class PerformanceService {
     private final PerformanceRepository performanceRepository;
     private final HallRepository hallRepository;
     private final CastRepository castRepository;
+    private final PerformanceSessionRepository performanceSessionRepository;
+    private final PerformanceSectionRepository performanceSectionRepository;
+    private final PerformanceSeatRepository performanceSeatRepository;
 
     /* 공연 생성 */
     @Transactional
@@ -254,6 +263,19 @@ public class PerformanceService {
 
         // 공연 삭제
         performance.delete();
+        // 공연 회차 삭제
+        List<PerformanceSession> sessions = performanceSessionRepository.findByPerformanceAndDeletedAtIsNull(performance);
+        sessions.forEach(PerformanceSession::delete);
+        // 회차 구역 삭제
+        for(PerformanceSession session: sessions){
+            List<PerformanceSection> sections = performanceSectionRepository.findByPerformanceSessionAndDeletedAtIsNull(session);
+            sections.forEach(PerformanceSection::delete);
+            // 회차 구역 좌석 삭제
+            for(PerformanceSection section: sections){
+                List<PerformanceSeat> seats = performanceSeatRepository.findByPerformanceSectionAndDeletedAtIsNull(section);
+                seats.forEach(PerformanceSeat::delete);
+            }
+        }
         return null;
     }
 }

--- a/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceSessionService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/service/PerformanceSessionService.java
@@ -1,0 +1,48 @@
+package com.dayaeyak.performance.domain.performance.service;
+
+import com.dayaeyak.performance.common.exception.CustomException;
+import com.dayaeyak.performance.domain.performance.dto.request.CreateSessionRequestDto;
+import com.dayaeyak.performance.domain.performance.dto.response.CreateSessionResponseDto;
+import com.dayaeyak.performance.domain.performance.entity.Performance;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSession;
+import com.dayaeyak.performance.domain.performance.exception.PerformanceErrorCode;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceRepository;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PerformanceSessionService {
+    private final PerformanceSessionRepository performanceSessionRepository;
+    private final PerformanceRepository performanceRepository;
+
+    /* 공연 회차 생성 */
+    @Transactional
+    public CreateSessionResponseDto createSession(Long performanceId, CreateSessionRequestDto requestDto){
+        // 경로 변수의 공연 ID와 요청 DTO의 공연 ID가 일치하지 않을 시 예외
+        if(!Objects.equals(performanceId, requestDto.performanceId())){
+            throw new CustomException(PerformanceErrorCode.MISMATCHED_PERFORMANCE_ID);
+        }
+
+        // 공연 ID로 공연 찾기
+        Performance performance = performanceRepository.findByPerformanceIdAndDeletedAtIsNull(performanceId)
+                .orElseThrow(() -> new CustomException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND));
+
+        // 공연 회차 날짜가 시작일/마감일 범위가 아니면 예외 처리
+        if(requestDto.date().isBefore(performance.getStartDate()) || requestDto.date().isAfter(performance.getEndDate())){
+            throw new CustomException(PerformanceErrorCode.INVALID_SESSION_DATE);
+        }
+
+        // 공연 회차 엔티티 생성 및 저장
+        PerformanceSession session = new PerformanceSession(performance, requestDto.date(), requestDto.time());
+        PerformanceSession savedSession = performanceSessionRepository.save(session);
+
+        // 응답 DTO 반환
+        return new CreateSessionResponseDto(savedSession.getPerformanceSessionId());
+    }
+}

--- a/src/main/java/com/dayaeyak/performance/domain/performance/service/SeatService.java
+++ b/src/main/java/com/dayaeyak/performance/domain/performance/service/SeatService.java
@@ -1,0 +1,91 @@
+package com.dayaeyak.performance.domain.performance.service;
+
+import com.dayaeyak.performance.common.exception.CustomException;
+import com.dayaeyak.performance.domain.performance.dto.request.UpdateSeatSoldOutRequestDto;
+import com.dayaeyak.performance.domain.performance.dto.response.SeatResponseDto;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSeat;
+import com.dayaeyak.performance.domain.performance.entity.PerformanceSection;
+import com.dayaeyak.performance.domain.performance.exception.PerformanceErrorCode;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSeatRepository;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSectionRepository;
+import com.dayaeyak.performance.domain.performance.repository.PerformanceSessionRepository;
+import com.dayaeyak.performance.utils.DistributedLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SeatService {
+    private final PerformanceSectionRepository performanceSectionRepository;
+    private final PerformanceSessionRepository performanceSessionRepository;
+    private final PerformanceSeatRepository performanceSeatRepository;
+
+    /* 공연 회차 구역 좌석 품절 여부 변경 (분산락 적용)*/
+    @DistributedLock(key = "'seat:' + #seatId")
+    @Transactional
+    public SeatResponseDto changeIsSoldOut(
+            Long performanceId,
+            Long sessionId,
+            Long sectionId,
+            Long seatId,
+            UpdateSeatSoldOutRequestDto requestDto) {
+
+        log.info("좌석 품절 상태 변경 시작 - seatId: {}, soldOut: {}", seatId, requestDto.isSoldOut());
+
+        // 좌석 조회
+        PerformanceSeat seat = performanceSeatRepository.findByPerformanceSeatIdAndDeletedAtIsNull(seatId)
+                .orElseThrow(() -> new CustomException(PerformanceErrorCode.SEAT_NOT_FOUND));
+
+        // 구역 조회
+        PerformanceSection section = performanceSectionRepository.findByPerformanceSectionIdAndDeletedAtIsNull(sectionId)
+                .orElseThrow(() -> new CustomException(PerformanceErrorCode.SECTION_NOT_FOUND));
+
+        // 좌석이 요청한 구역에 속하는지 검증
+        if (!Objects.equals(seat.getPerformanceSection().getPerformanceSectionId(), sectionId)) {
+            throw new CustomException(PerformanceErrorCode.MISMATCHED_SECTION_AND_SEAT);
+        }
+
+        // 구역이 요청한 회차에 속하는지 검증
+        if (!Objects.equals(seat.getPerformanceSection().getPerformanceSession().getPerformanceSessionId(), sessionId)) {
+            throw new CustomException(PerformanceErrorCode.MISMATCHED_SESSION_AND_SECTION);
+        }
+
+        // 회차가 요청한 공연에 속하는지 검증
+        if (!Objects.equals(seat.getPerformanceSection().getPerformanceSession().getPerformance().getPerformanceId(), performanceId)) {
+            throw new CustomException(PerformanceErrorCode.MISMATCHED_PERFORMANCE_AND_SESSION);
+        }
+
+        // 품절 상태 변경 및 구역 잔여좌석수 업데이트
+        if (requestDto.isSoldOut()) {
+            // true로 요청한 경우 (품절 처리)
+            if (seat.getIsSoldOut()) {
+                throw new CustomException(PerformanceErrorCode.SEAT_ALREADY_SOLD_OUT);
+            }
+            seat.sellOut();
+            section.decreaseRemainingSeats();   // 해당 구역의 잔여좌석수 -1
+            log.info("좌석 품절 처리 완료 - seatId: {}", seatId);
+        } else {
+            // false로 요청한 경우 (품절 해제)
+            if (!seat.getIsSoldOut()) {
+                throw new CustomException(PerformanceErrorCode.SEAT_ALREADY_OPEN);
+            }
+            seat.reopen();
+            section.increaseRemainingSeats();   // 해당 구역의 잔여좌석수 +1
+            log.info("좌석 품절 해제 완료 - seatId: {}", seatId);
+        }
+
+        // 6. 응답 DTO 생성 및 반환
+        return SeatResponseDto.from(seat);
+    }
+
+    /* 공연 회차 구역 좌석 조회 */
+
+    /* 공연 회차 구역 좌석 전체 조회 */
+
+}

--- a/src/main/java/com/dayaeyak/performance/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dayaeyak/performance/handler/GlobalExceptionHandler.java
@@ -30,6 +30,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
-        return ApiResponse.error(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 요청입니다.");
+        String message = (e.getMessage() != null && !e.getMessage().isBlank())
+                ? e.getMessage() : "유효하지 않은 요청입니다.";
+        return ApiResponse.error(HttpStatus.BAD_REQUEST.value(), message);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalStateException(IllegalStateException e) {
+        return ApiResponse.error(HttpStatus.CONFLICT.value(), e.getMessage());
     }
 }

--- a/src/main/java/com/dayaeyak/performance/utils/DistributedLock.java
+++ b/src/main/java/com/dayaeyak/performance/utils/DistributedLock.java
@@ -1,0 +1,14 @@
+package com.dayaeyak.performance.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    String key(); // 락 키
+    long waitTime() default 3000L; // 락 획득 대기시간 (ms)
+    long leaseTime() default 5000L; // 락 보유시간 (ms)
+}

--- a/src/main/java/com/dayaeyak/performance/utils/DistributedLockAspect.java
+++ b/src/main/java/com/dayaeyak/performance/utils/DistributedLockAspect.java
@@ -1,0 +1,77 @@
+package com.dayaeyak.performance.utils;
+
+import com.dayaeyak.performance.common.exception.CustomException;
+import com.dayaeyak.performance.domain.performance.exception.PerformanceErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Order(1) // 트랜잭션보다 먼저 실행되도록
+public class DistributedLockAspect {
+
+    private final RedissonClient redissonClient;
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    @Around("@annotation(distributedLock)")
+    public Object around(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        String lockKey = generateLockKey(joinPoint, distributedLock.key());
+        RLock lock = redissonClient.getLock(lockKey);
+
+        boolean acquired = false;
+        try {
+            // 락 획득 시도
+            acquired = lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), TimeUnit.MILLISECONDS);
+
+            if (!acquired) {
+                log.warn("분산 락 획득 실패: {}", lockKey);
+                throw new CustomException(PerformanceErrorCode.LOCK_ACQUISITION_FAILED);
+            }
+
+            log.debug("분산 락 획득 성공: {}", lockKey);
+            return joinPoint.proceed();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(PerformanceErrorCode.LOCK_INTERRUPTED);
+        } finally {
+            if (acquired && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.debug("분산 락 해제: {}", lockKey);
+            }
+        }
+    }
+
+    private String generateLockKey(ProceedingJoinPoint joinPoint, String keyExpression) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Object[] args = joinPoint.getArgs();
+        String[] paramNames = signature.getParameterNames();
+
+        EvaluationContext context = new StandardEvaluationContext();
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
+        }
+
+        Expression expression = parser.parseExpression(keyExpression);
+        return "LOCK:" + expression.getValue(context, String.class);
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)
공연 회차, 구역, 좌석 API 만들고 공연 검색에 지역별 조건 추가했습니다.
그리고 공연장 도메인 만들 때, hall_sections 테이블에 좌석별 가격을 넣는 실수를 했더라구요..🫠
hall_sections 테이블에서 삭제하고 performance_sections 테이블에 가격 넣는 걸로 수정하고, ERD 업데이트했습니다!

## 💫 구현 및 변경 사항 (Details)
- 공연 회차 생성 API
  - 회차 생성 시 구역, 좌석 테이블 자동 생성
  - 요청 본문으로 각 구역의 좌석별 가격을 받음
- 공연 회차 수정/삭제 API
  - 티켓오픈시간 이후에는 수정 및 삭제 불가
- 공연 회차 조회 API
  - 단건 및 전체 조회만 가능
- 공연 회차 구역 조회 API
  - 단건 및 전체 조회만 가능
- 좌석 조회 API
  - 좌석 단건 조회 시 상세 정보 포함
  - 좌석 전체 조회 시 해당 구역의 좌석의 품절 여부만 리스트로 응답
- 좌석 품절 여부 변경 API 
  - Redis 분산락 적용 (동시성 제어)
  - 좌석 품절 여부 변경 시 해당 구역의 잔여 좌석 수 자동 변경
- 공연 검색 조건 추가 (지역별 검색)

## ✅ 체크리스트
- [x] 코드 정상 작동 테스트 완료
- [x] API 명세서 업데이트
- [x] 팀의 코드 컨벤션 준수
- [x] Reviewers에 팀원 등록

## 💬 TODO ( 미완성일 경우 )
- 권한 확인 로직 추가 필요

## 기타/주의사항
조금 많이 길어요..ㅎ